### PR TITLE
Cross resonance Rabi experiment and rough amplitude calibration

### DIFF
--- a/qiskit_experiments/library/__init__.py
+++ b/qiskit_experiments/library/__init__.py
@@ -67,6 +67,7 @@ Some experiments also have a calibration experiment version.
     ~characterization.FineSXAmplitude
     ~characterization.Rabi
     ~characterization.EFRabi
+    ~characterization.CrossResRabi
     ~characterization.RamseyXY
     ~characterization.FineFrequency
     ~characterization.ReadoutAngle
@@ -172,6 +173,7 @@ from .characterization import (
     FineSXDrag,
     Rabi,
     EFRabi,
+    CrossResRabi,
     HalfAngle,
     FineAmplitude,
     FineXAmplitude,

--- a/qiskit_experiments/library/characterization/__init__.py
+++ b/qiskit_experiments/library/characterization/__init__.py
@@ -32,6 +32,7 @@ Experiments
     EchoedCrossResonanceHamiltonian
     Rabi
     EFRabi
+    CrossResRabi
     HalfAngle
     FineAmplitude
     FineXAmplitude
@@ -102,7 +103,7 @@ from .t2ramsey import T2Ramsey
 from .t2hahn import T2Hahn
 from .tphi import Tphi
 from .cr_hamiltonian import CrossResonanceHamiltonian, EchoedCrossResonanceHamiltonian
-from .rabi import Rabi, EFRabi
+from .rabi import Rabi, EFRabi, CrossResRabi
 from .half_angle import HalfAngle
 from .fine_amplitude import FineAmplitude, FineXAmplitude, FineSXAmplitude, FineZXAmplitude
 from .ramsey_xy import RamseyXY, StarkRamseyXY

--- a/releasenotes/notes/add-rough-cr-amp-e666ded368737b04.yaml
+++ b/releasenotes/notes/add-rough-cr-amp-e666ded368737b04.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Add characterization and calibration experiment for cross resonance amplitude,
+    :class:`.CrossResRabi` and :class:`.CrossResRoughAmplitudeCal`, respectively.

--- a/test/library/calibration/test_rough_amplitude.py
+++ b/test/library/calibration/test_rough_amplitude.py
@@ -175,3 +175,12 @@ class TestSpecializations(QiskitExperimentsTestCase):
         self.assertTrue(
             abs(self.cals.get_parameter_value("amp", 0, "sx12") * (4 / 5) - default_amp / 2) < tol
         )
+
+
+class TestCrossResRoughAmplitudeCal(QiskitExperimentsTestCase):
+    """Test case for CrossResRoughAmplitudeCal experiment."""
+
+    def test_end_to_end(self):
+        """End-to-end testing of calibration experiment."""
+        # TODO implement this
+        pass


### PR DESCRIPTION
### Summary

This PR adds characterization and calibration experiment for cross resonance pulse amplitude. It drives the control qubit at a frequency of the target qubit, and measure the population of the target qubit and fit the data with the oscillation analysis.

### Details and comments

New experiment is written in the style recently I started to use in my project, aiming at future parametric circuit execution. If this looks good, I'll refactor other experiments in the followup.

Added features are 

```python

    parameter = Parameter("some_name")
    # class variable of the parameter object to use in this class

    def parameterized_circuits(self) -> Tuple[QuantumCircuit, ...]:
        # Return parameterized circuits

    def parameters(self) -> np.ndarray:
        # Return parameter values
```

Then the conventional `BaseExperiment.circuits` method consumes new `parameterized_circuits` and `parameters` output to build circuit. For example, the parameters method can consider the hardware constrains such as granularity. There is no API break with this implementation.

### PR checklist (delete when all criteria are met)

- [x] I have read the contributing guide `CONTRIBUTING.md`.
- [ ] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have added a release note file using `reno` if this change needs to be documented in the release notes.
