### PR TITLE
Better HGP handling in `ExperimentData`

### DIFF
--- a/qiskit_experiments/framework/experiment_data.py
+++ b/qiskit_experiments/framework/experiment_data.py
@@ -642,7 +642,7 @@ class ExperimentData:
                 project = creds.project
             # qiskit-ibm-provider style
             if hasattr(provider, "_hgps"):
-                for hgp_string, hgp in self.backend.provider._hgps.items():
+                for hgp_string, hgp in provider._hgps.items():
                     if self.backend.name in hgp.backends:
                         hub, group, project = hgp_string.split("/")
                         break
@@ -651,6 +651,19 @@ class ExperimentData:
             self._db_data.project = self._db_data.project or project
         except (AttributeError, IndexError):
             return
+
+    @property
+    def hgp(self) -> str:
+        """Returns Hub/Group/Project data as a formatted string"""
+        return f"{self.hub}/{self.group}/{self.project}"
+
+    @hgp.setter
+    def hgp(self, new_hgp: str) -> None:
+        """Sets the Hub/Group/Project data from a formatted string"""
+        hub, group, project = new_hgp.split("/")
+        self._db_data.hub = self._db_data.hub or hub
+        self._db_data.group = self._db_data.group or group
+        self._db_data.project = self._db_data.project or project
 
     def _clear_results(self):
         """Delete all currently stored analysis results and figures"""

--- a/qiskit_experiments/framework/experiment_data.py
+++ b/qiskit_experiments/framework/experiment_data.py
@@ -655,10 +655,7 @@ class ExperimentData:
         """Sets the Hub/Group/Project data from a formatted string"""
         if re.match(r"\w+/\w+/\w+$", new_hgp) is None:
             raise QiskitError("hgp can be only given in a <hub>/<group>/<project> format")
-        hub, group, project = new_hgp.split("/")
-        self._db_data.hub = hub
-        self._db_data.group = group
-        self._db_data.project = project
+        self._db_data.hub, self._db_data.group, self._db_data.project = new_hgp.split("/")
 
     def _clear_results(self):
         """Delete all currently stored analysis results and figures"""

--- a/qiskit_experiments/framework/experiment_data.py
+++ b/qiskit_experiments/framework/experiment_data.py
@@ -632,9 +632,6 @@ class ExperimentData:
 
     def _set_hgp_from_provider(self, provider):
         try:
-            hub = None
-            group = None
-            project = None
             # qiskit-ibmq-provider style
             if hasattr(provider, "credentials"):
                 creds = provider.credentials

--- a/qiskit_experiments/framework/experiment_data.py
+++ b/qiskit_experiments/framework/experiment_data.py
@@ -642,7 +642,7 @@ class ExperimentData:
                     if self.backend.name in hgp.backends:
                         self.hgp = hgp_string
                         break
-        except (AttributeError, IndexError):
+        except (AttributeError, IndexError, QiskitError):
             return
 
     @property


### PR DESCRIPTION
### Summary

This PR enables easier work with the Hub/Group/Project data in `ExperimentData`

### Details and comments

This PR does the following changes:
1. Adds setter/getter for a `hgp` field of `ExperimentData` to enable the users to easily control those fields.
2. Fixes a bug in `_set_hgp_from_provider` to ensure the correct hgp will be extracted.