### PR TITLE
Revising the completion_times property

### DIFF
--- a/test/database_service/test_db_experiment_data.py
+++ b/test/database_service/test_db_experiment_data.py
@@ -724,6 +724,19 @@ class TestDbExperimentData(QiskitExperimentsTestCase):
         self.assertEqual(exp_data.analysis_status(), AnalysisStatus.CANCELLED)
         self.assertEqual(exp_data.status(), ExperimentStatus.CANCELLED)
 
+    def test_completion_times(self):
+        """Test the completion_times property"""
+        jid = "1234"
+        job = mock.create_autospec(Job, instance=True)
+        job.job_id.return_value = jid
+        job.status = JobStatus.DONE
+
+        exp_data = ExperimentData(experiment_type="qiskit_test")
+        exp_data.add_jobs(job)
+        completion_times = exp_data.completion_times
+        self.assertTrue(jid in completion_times)
+        self.assertTrue(isinstance(completion_times[jid], datetime))
+
     def test_partial_cancel_analysis(self):
         """Test canceling experiment analysis."""
 


### PR DESCRIPTION
### Summary

This PR updates the handling of the `completion_times` property in `ExperimentData`

### Details and comments

Currently, the `completion_times` property is highly dependent on the structure of the job classes metadata, resulting in the property not working correctly (e.g. when using fake backends or the new `qiskit-ibm-provider`).

This PR switches handling of `completion_times` to `ExperimentData` itself, which keeps track of this info anyway when computing `end_datetime`.

Addresses #1205.
