### PR TITLE
Reduce tomography test length

### DIFF
--- a/test/library/tomography/test_process_tomography.py
+++ b/test/library/tomography/test_process_tomography.py
@@ -476,8 +476,8 @@ class TestProcessTomography(QiskitExperimentsTestCase):
     def test_mitigated_full_qpt_random_unitary(self, qubits):
         """Test QPT experiment"""
         seed = 1234
-        shots = 5000
-        f_threshold = 0.95
+        shots = 1000
+        f_threshold = 0.9
 
         noise_model = readout_noise_model(4, seed=seed)
         backend = AerSimulator(seed_simulator=seed, shots=shots, noise_model=noise_model)

--- a/test/library/tomography/test_process_tomography.py
+++ b/test/library/tomography/test_process_tomography.py
@@ -483,6 +483,7 @@ class TestProcessTomography(QiskitExperimentsTestCase):
         backend = AerSimulator(seed_simulator=seed, shots=shots, noise_model=noise_model)
         target = qi.random_unitary(2 ** len(qubits), seed=seed)
         exp = MitigatedProcessTomography(target, backend=backend)
+        exp.set_transpile_options(seed_transpiler=42)
         exp.analysis.set_options(unmitigated_fit=True)
         expdata = exp.run(analysis=None)
         self.assertExperimentDone(expdata)


### PR DESCRIPTION
### Summary

We've seen a lot of random test failures from `test_mitigated_full_qpt_random_unitary` timing out, so this PR reduces the number of shots, adjusts the threshold, and fixes the transpiler seed.
