### PR TITLE
Fix calculation of curve fit weights

### DIFF
--- a/qiskit_experiments/curve_analysis/curve_analysis.py
+++ b/qiskit_experiments/curve_analysis/curve_analysis.py
@@ -361,14 +361,15 @@ class CurveAnalysis(BaseCurveAnalysis):
                 )
 
             try:
-                new = lmfit.minimize(
-                    fcn=_objective,
-                    params=guess_params,
-                    method=self.options.fit_method,
-                    scale_covar=not valid_uncertainty,
-                    nan_policy="omit",
-                    **fit_option.fitter_opts,
-                )
+                with np.errstate(all="ignore"):
+                    new = lmfit.minimize(
+                        fcn=_objective,
+                        params=guess_params,
+                        method=self.options.fit_method,
+                        scale_covar=not valid_uncertainty,
+                        nan_policy="omit",
+                        **fit_option.fitter_opts,
+                    )
             except Exception:  # pylint: disable=broad-except
                 continue
 

--- a/releasenotes/notes/fix-curve-fit-weights-fb43d3aa5ed1c91c.yaml
+++ b/releasenotes/notes/fix-curve-fit-weights-fb43d3aa5ed1c91c.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Fix calculation of weight for curve fitting. Previously the weights of data points to obtain
+    the residual of fit curve were computed by the inverse of the error bars of y data. 
+    This may yield significant weights on certain data points when their error bar is small or zero,
+    and this can cause the local overfit to these data points. 
+    To avoid this edge case of small error bars, computed weights are now clipped at 90 percentile. 
+    This update might slightly change the outcome of fit.

--- a/test/library/calibration/test_ramsey_xy.py
+++ b/test/library/calibration/test_ramsey_xy.py
@@ -56,7 +56,7 @@ class TestRamseyXY(QiskitExperimentsTestCase):
 
         This test also checks that we can pickup frequency shifts with different signs.
         """
-        test_tol = 0.01
+        test_tol = 0.03
         abs_tol = max(1e3, abs(freq_shift) * test_tol)
 
         exp_helper = RamseyXYHelper()


### PR DESCRIPTION
### Summary

This PR updates calculation of weights to compute residual in the curve fitting.

### Details and comments

When the error bar of data points is significantly small, these data points become a dominant source of residual to minimize. This means other data points contribute little to the fit, and causes local overfit to certain data points. This is fixed by clipping the weights to remove outlier.

