### PR TITLE
Bugfix in hgp setter in `ExperimentData`

### DIFF
--- a/qiskit_experiments/framework/experiment_data.py
+++ b/qiskit_experiments/framework/experiment_data.py
@@ -654,7 +654,7 @@ class ExperimentData:
     @hgp.setter
     def hgp(self, new_hgp: str) -> None:
         """Sets the Hub/Group/Project data from a formatted string"""
-        if re.match(r"\w+/\w+/\w+$", new_hgp) is None:
+        if re.match(r"[^/]*/[^/]*/[^/]*$", new_hgp) is None:
             raise QiskitError("hgp can be only given in a <hub>/<group>/<project> format")
         self._db_data.hub, self._db_data.group, self._db_data.project = new_hgp.split("/")
 

--- a/test/database_service/test_db_experiment_data.py
+++ b/test/database_service/test_db_experiment_data.py
@@ -1125,3 +1125,12 @@ class TestDbExperimentData(QiskitExperimentsTestCase):
             for n in range(metadata_size)
         ]
         self.assertTrue(exp_data._metadata_too_large())
+
+    def test_hgp_setter(self):
+        """Tests usage of the hgp setter"""
+        exp_data = ExperimentData()
+        exp_data.hgp = "ibm-q-internal/deployed/default"
+        self.assertEqual("ibm-q-internal/deployed/default", exp_data.hgp)
+        self.assertEqual("ibm-q-internal", exp_data.hub)
+        self.assertEqual("deployed", exp_data.group)
+        self.assertEqual("default", exp_data.project)


### PR DESCRIPTION
### Summary
This PR fixes a bug in :meth:`.ExperimentData.hgp`.

### Details and comments
Currently  :meth:`.ExperimentData.hgp` uses a regex which is too strict and cannot recognize strings such as "ibm-q-internal". This PR updates the regex to accept everything of the form "A/B/C" where A,B,C do not contain "/" but can contain anything else.
