### PR TITLE
Speed up non-production docs builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -98,7 +98,7 @@ jobs:
           python -m pip install -U tox
           sudo apt-get install -y pandoc graphviz
       - name: Build Docs
-        run: tox -edocs
+        run: tox -edocs-parallel
       - name: Compress Artifacts
         run: |
           mkdir artifacts

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -53,7 +53,6 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
     "sphinx.ext.mathjax",
-    "sphinx.ext.viewcode",
     "sphinx.ext.extlinks",
     "sphinx_copybutton",
     "jupyter_sphinx",
@@ -69,10 +68,13 @@ extensions = [
     "sphinx_remove_toctrees",
 ]
 
-# Remove stubs from the toctree by default because the full build is slow
-# This is turned off for docs deployment
-if not os.getenv("FULL_TOCTREE", None):
+if os.getenv("PROD_BUILD", None):
+    # Turn on view code source for production build
+    extensions.append("sphinx.ext.viewcode")
+else:
+    # Remove stubs from the toctree for non-prod build because the full build is slow
     remove_from_toctrees = ["stubs/*"]
+
 
 html_static_path = ["_static"]
 templates_path = ["_templates"]

--- a/docs/manuals/verification/randomized_benchmarking.rst
+++ b/docs/manuals/verification/randomized_benchmarking.rst
@@ -161,7 +161,7 @@ for the single qubit channel :math:`n=1`. Accordingly,
 
 as a composition of depolarization from every primitive gates per qubit.
 This correction will give you two EPC values as a result of the two-qubit RB experiment.
-The corrected EPC must be closer to the outcome of of interleaved RB.
+The corrected EPC must be closer to the outcome of interleaved RB.
 The EPGs of two-qubit RB are analyzed with the corrected EPC if available.
 
 .. jupyter-execute::

--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -14,7 +14,6 @@ The Basics
     :maxdepth: 2
 
     intro
-    getting_started
     
 Exploring Modules
 -----------------

--- a/qiskit_experiments/framework/__init__.py
+++ b/qiskit_experiments/framework/__init__.py
@@ -24,10 +24,9 @@ The experiment framework broadly defines an experiment as the execution of one o
 circuits on a device, and analysis of the resulting measurement data
 to return one or more derived results.
 
-The interface for running an experiment is through the *Experiment* classes,
-such as those contained in the :mod:`~qiskit_experiments.library`.
-The following pseudo-code illustrates the typical workflow in Qiskit Experiments
-for
+The interface for running an experiment is through the ``Experiment`` classes subclassed from
+:class:`.BaseExperiment`, such as those contained in the :mod:`~qiskit_experiments.library`. The
+following pseudo-code illustrates the typical workflow in Qiskit Experiments for
 
 - Initializing a new experiment
 - Running the experiment on a backend

--- a/qiskit_experiments/framework/analysis_result.py
+++ b/qiskit_experiments/framework/analysis_result.py
@@ -211,7 +211,7 @@ class AnalysisResult:
         """Save this analysis result in the database.
         Args:
             suppress_errors: should the method catch exceptions (true) or
-            pass them on, potentially aborting the experiemnt (false)
+            pass them on, potentially aborting the experiment (false)
         Raises:
             ExperimentDataError: If the analysis result contains invalid data.
             QiskitError: If the save to the database failed

--- a/qiskit_experiments/framework/experiment_data.py
+++ b/qiskit_experiments/framework/experiment_data.py
@@ -1440,7 +1440,7 @@ class ExperimentData:
         """Save this experiments metadata to a database service.
         Args:
             suppress_errors: should the method catch exceptions (true) or
-            pass them on, potentially aborting the experiemnt (false)
+            pass them on, potentially aborting the experiment (false)
         Raises:
             QiskitError: If the save to the database failed
         .. note::
@@ -1506,7 +1506,7 @@ class ExperimentData:
 
         Args:
             suppress_errors: should the method catch exceptions (true) or
-            pass them on, potentially aborting the experiemnt (false)
+            pass them on, potentially aborting the experiment (false)
             max_workers: Maximum number of concurrent worker threads (capped by 10)
             save_figures: Whether to save figures in the database or not
             save_children: For composite experiments, whether to save children as well
@@ -2214,7 +2214,7 @@ class ExperimentData:
         for data in self._child_data.values():
             data.remove_tags_recursive(tags2remove)
 
-    # represetnation and serialization
+    # representation and serialization
 
     def __repr__(self):
         out = f"{type(self).__name__}({self.experiment_type}"

--- a/qiskit_experiments/library/__init__.py
+++ b/qiskit_experiments/library/__init__.py
@@ -17,7 +17,7 @@ Experiment Library (:mod:`qiskit_experiments.library`)
 
 .. currentmodule:: qiskit_experiments.library
 
-A library of of quantum characterization, calibration and verification
+A library of quantum characterization, calibration and verification
 experiments for calibrating and benchmarking quantum devices. See
 :mod:`qiskit_experiments.framework` for general information on the framework
 for running experiments.

--- a/tools/deploy_documentation.sh
+++ b/tools/deploy_documentation.sh
@@ -21,7 +21,7 @@ sudo apt-get install -y ./rclone.deb
 RCLONE_CONFIG_PATH=$(rclone config file | tail -1)
 
 # Build the documentation.
-EXPERIMENTS_DEV_DOCS=1 FULL_TOCTREE=1 tox -edocs
+EXPERIMENTS_DEV_DOCS=1 PROD_BUILD=1 tox -edocs
 
 echo "show current dir: "
 pwd

--- a/tools/deploy_documentation_dev.sh
+++ b/tools/deploy_documentation_dev.sh
@@ -21,7 +21,7 @@ sudo apt-get install -y ./rclone.deb
 RCLONE_CONFIG_PATH=$(rclone config file | tail -1)
 
 # Build the documentation.
-EXPERIMENTS_DEV_DOCS=1 FULL_TOCTREE=1 RELEASE_STRING=`git describe` tox -edocs
+EXPERIMENTS_DEV_DOCS=1 PROD_BUILD=1 RELEASE_STRING=`git describe` tox -edocs
 
 echo "show current dir: "
 pwd

--- a/tox.ini
+++ b/tox.ini
@@ -72,7 +72,7 @@ commands = black {posargs} qiskit_experiments test tools setup.py
 usedevelop = False
 passenv =
   EXPERIMENTS_DEV_DOCS
-  FULL_TOCTREE
+  PROD_BUILD
   RELEASE_STRING
   VERSION_STRING
 commands =
@@ -81,8 +81,7 @@ commands =
 [testenv:docs-parallel]
 usedevelop = False
 passenv =
-  EXPERIMENTS_DEV_DOCS
-  FULL_TOCTREE
+  PROD_BUILD
   RELEASE_STRING
   VERSION_STRING
 commands =
@@ -91,8 +90,7 @@ commands =
 [testenv:docs-minimal]
 usedevelop = False
 passenv =
-  EXPERIMENTS_DEV_DOCS
-  FULL_TOCTREE
+  PROD_BUILD
   RELEASE_STRING
   VERSION_STRING
 setenv = 

--- a/tox.ini
+++ b/tox.ini
@@ -81,6 +81,7 @@ commands =
 [testenv:docs-parallel]
 usedevelop = False
 passenv =
+  EXPERIMENTS_DEV_DOCS
   PROD_BUILD
   RELEASE_STRING
   VERSION_STRING
@@ -90,6 +91,7 @@ commands =
 [testenv:docs-minimal]
 usedevelop = False
 passenv =
+  EXPERIMENTS_DEV_DOCS
   PROD_BUILD
   RELEASE_STRING
   VERSION_STRING


### PR DESCRIPTION
### Summary

This PR turns off source code viewing for non-production builds to speed them up (the speed up seems to be only ~2 minutes, but better than nothing). It also turns on parallel builds for CI which was disabled because of random crashes on MacOS, but that shouldn't be a problem for CI since it's on Ubuntu (this speed up is around ~8 minutes). The `FULL_TOCTREE` flag has been changed to `PROD_BUILD` to encompass all the changes needed for a production vs. non-production build.

In addition, Getting Started has been removed from the tutorials index so that it doesn't show up twice on the sidebar. Some typos have been fixed.