### PR TITLE
Make CI tests faster

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,11 +43,11 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |
-          ~/.stestr/0
-          ~/.stestr/f*
-          ~/.stestr/m*
-          ~/.stestr/n*
-          ~/.stestr/t*
+            ~/.stestr/0
+            ~/.stestr/f*
+            ~/.stestr/m*
+            ~/.stestr/n*
+            ~/.stestr/t*
           key: ${{ runner.os }}-${{ matrix.python-version }}-stestr-tests-${{ hashFiles('setup.py','requirements.txt','requirements-extras.txt','requirements-dev.txt','constraints.txt') }}
           restore-keys: |
             ${{ runner.os }}-${{ matrix.python-version }}-stestr-tests-

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,8 +42,10 @@ jobs:
       - name: Stestr cache
         uses: actions/cache@v3
         with:
-          path: .stestr/times.*
-          key: stestr-${{ runner.os }}-${{ matrix.python-version }}-${{ env.GITHUB_RUN_NUMBER }}
+          path: |
+            .stestr/times.*
+            .stestr/format
+          key: stestr-${{ runner.os }}-${{ matrix.python-version }}-${{ github.run_number }}
           restore-keys: |
             stestr-${{ runner.os }}-${{ matrix.python-version }}-
             stestr-

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,15 +45,14 @@ jobs:
           path: .stestr
           key: stestr-${{ runner.os }}-${{ matrix.python-version }}
           restore-keys: |
-            stestr-${{ runner.os }}-${{ matrix.python-version }}
             stestr-${{ runner.os }}-
             stestr-
       - name: Install Deps
-        run: python -m pip install -U tox setuptools virtualenv wheel
+        run: python -m pip install -U tox setuptools virtualenv wheel stestr
       - name: Install and Run Tests
         run: tox -e py
       - name: Clean up stestr cache
-        run: tox -e stestr-clean
+        run: stestr history remove all
 
   lint:
     name: lint

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,6 +45,7 @@ jobs:
           path: |
             .stestr/times.*
             .stestr/format
+            .stestr/next-stream
           key: stestr-${{ runner.os }}-${{ matrix.python-version }}-${{ github.run_number }}
           restore-keys: |
             stestr-${{ runner.os }}-${{ matrix.python-version }}-

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10", "3.11"]
+        python-version: [3.8, "3.11"]
         os: ["ubuntu-latest", "macOS-latest", "windows-latest"]
     steps:
       - name: Print Concurrency Group
@@ -40,24 +40,12 @@ jobs:
             ${{ runner.os }}-${{ matrix.python-version }}-pip-
             ${{ runner.os }}-${{ matrix.python-version }}
       - name: Install Deps
-        run: python -m pip install -U "tox==3.27.1" setuptools virtualenv wheel
-      - name: Install and Run Tests (Windows and Linux)
+        run: python -m pip install -U tox setuptools virtualenv wheel
+      - name: Install and Run Tests
         run: tox -e py
-        if: runner.os != 'macOS'
-      - name: Install and Run Tests (Macs only)
-        run: tox -e cover
         if: runner.os == 'macOS'
         env:
           OMP_NUM_THREADS: 1
-      - name: Report coverage to coveralls.io (Macs only)
-        if: runner.os == 'macOS'
-        uses: coverallsapp/github-action@v2
-        env:
-          ACTIONS_RUNNER_DEBUG: 1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          flag-name: unit-tests_python${{ matrix.python-version }}-${{ matrix.os }}
-          path-to-lcov: coverage.lcov
 
   lint:
     name: lint

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,16 +43,19 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |
-            ~/.stestr/0
-            ~/.stestr/f*
-            ~/.stestr/m*
-            ~/.stestr/n*
-            ~/.stestr/t*
+            .stestr/0
+            .stestr/f*
+            .stestr/m*
+            .stestr/n*
+            .stestr/t*
           key: ${{ runner.os }}-${{ matrix.python-version }}-stestr-tests-${{ hashFiles('setup.py','requirements.txt','requirements-extras.txt','requirements-dev.txt','constraints.txt') }}
           restore-keys: |
             ${{ runner.os }}-${{ matrix.python-version }}-stestr-tests-
       - name: Install Deps
         run: python -m pip install -U tox setuptools virtualenv wheel
+      - name: Install and Run Tests
+        run: tox -e py
+        if: runner.os != 'macOS'
       - name: Install and Run Tests
         run: tox -e py
         if: runner.os == 'macOS'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,10 +57,20 @@ jobs:
         run: tox -e py
         if: runner.os != 'macOS'
       - name: Install and Run Tests
-        run: tox -e py
+        run: tox -e cover
         if: runner.os == 'macOS'
         env:
           OMP_NUM_THREADS: 1
+      - name: Report coverage to coveralls.io (Macs only)
+        if: runner.os == 'macOS'
+        uses: coverallsapp/github-action@v2
+        env:
+          ACTIONS_RUNNER_DEBUG: 1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          flag-name: unit-tests_python${{ matrix.python-version }}-${{ matrix.os }}
+          path-to-lcov: coverage.lcov
+  
 
   lint:
     name: lint

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,10 +42,7 @@ jobs:
       - name: Stestr cache
         uses: actions/cache@v3
         with:
-          path: |
-            .stestr/times.*
-            .stestr/format
-            .stestr/next-stream
+          path: .stestr
           key: stestr-${{ runner.os }}-${{ matrix.python-version }}-${{ github.run_number }}
           restore-keys: |
             stestr-${{ runner.os }}-${{ matrix.python-version }}-
@@ -54,6 +51,8 @@ jobs:
         run: python -m pip install -U tox setuptools virtualenv wheel
       - name: Install and Run Tests
         run: tox -e py
+      - name: Clean up stestr cache
+        run: tox -e stestr-clean
 
   lint:
     name: lint

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,18 @@ jobs:
             ${{ runner.os }}-${{ matrix.python-version }}-pip-tests-
             ${{ runner.os }}-${{ matrix.python-version }}-pip-
             ${{ runner.os }}-${{ matrix.python-version }}
+      - name: Stestr cache
+        uses: actions/cache@v3
+        with:
+          path: |
+          ~/.stestr/0
+          ~/.stestr/f*
+          ~/.stestr/m*
+          ~/.stestr/n*
+          ~/.stestr/t*
+          key: ${{ runner.os }}-${{ matrix.python-version }}-stestr-tests-${{ hashFiles('setup.py','requirements.txt','requirements-extras.txt','requirements-dev.txt','constraints.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.python-version }}-stestr-tests-
       - name: Install Deps
         run: python -m pip install -U tox setuptools virtualenv wheel
       - name: Install and Run Tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,22 +55,6 @@ jobs:
         run: python -m pip install -U tox setuptools virtualenv wheel
       - name: Install and Run Tests
         run: tox -e py
-        if: runner.os != 'macOS'
-      - name: Install and Run Tests
-        run: tox -e cover
-        if: runner.os == 'macOS'
-        env:
-          OMP_NUM_THREADS: 1
-      - name: Report coverage to coveralls.io (Macs only)
-        if: runner.os == 'macOS'
-        uses: coverallsapp/github-action@v2
-        env:
-          ACTIONS_RUNNER_DEBUG: 1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          flag-name: unit-tests_python${{ matrix.python-version }}-${{ matrix.os }}
-          path-to-lcov: coverage.lcov
-  
 
   lint:
     name: lint

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,15 +42,11 @@ jobs:
       - name: Stestr cache
         uses: actions/cache@v3
         with:
-          path: |
-            .stestr/0
-            .stestr/f*
-            .stestr/m*
-            .stestr/n*
-            .stestr/t*
-          key: ${{ runner.os }}-${{ matrix.python-version }}-stestr-tests-${{ hashFiles('setup.py','requirements.txt','requirements-extras.txt','requirements-dev.txt','constraints.txt') }}
+          path: .stestr/times.*
+          key: stestr-${{ runner.os }}-${{ matrix.python-version }}-${{ env.GITHUB_RUN_NUMBER }}
           restore-keys: |
-            ${{ runner.os }}-${{ matrix.python-version }}-stestr-tests-
+            stestr-${{ runner.os }}-${{ matrix.python-version }}-
+            stestr-
       - name: Install Deps
         run: python -m pip install -U tox setuptools virtualenv wheel
       - name: Install and Run Tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,9 +43,10 @@ jobs:
         uses: actions/cache@v3
         with:
           path: .stestr
-          key: stestr-${{ runner.os }}-${{ matrix.python-version }}-${{ github.run_number }}
+          key: stestr-${{ runner.os }}-${{ matrix.python-version }}
           restore-keys: |
-            stestr-${{ runner.os }}-${{ matrix.python-version }}-
+            stestr-${{ runner.os }}-${{ matrix.python-version }}
+            stestr-${{ runner.os }}-
             stestr-
       - name: Install Deps
         run: python -m pip install -U tox setuptools virtualenv wheel

--- a/.stestr.conf
+++ b/.stestr.conf
@@ -1,2 +1,3 @@
 [DEFAULT]
 test_path=./test
+parallel_class=True

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,6 +121,8 @@ To run a method:
 tox -- -n test.python.test_examples.TestPythonExamples.test_all_examples
 ```
 
+Note that tests will fail automatically if they do not finish execution within 60 seconds.
+
 #### STDOUT/STDERR and logging capture
 
 When running tests in parallel using `stestr` either via tox, the Makefile (`make

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![License](https://img.shields.io/github/license/Qiskit-Extensions/qiskit-experiments.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Release](https://img.shields.io/github/release/Qiskit-Extensions/qiskit-experiments.svg)](https://github.com/Qiskit-Extensions/qiskit-experiments/releases)
 ![Python](https://img.shields.io/pypi/pyversions/qiskit-experiments.svg)
-[![Coverage Status](https://coveralls.io/repos/github/Qiskit-Extensions/qiskit-experiments/badge.svg?branch=main)](https://coveralls.io/github/Qiskit-Extensions/qiskit-experiments?branch=main)
 [![DOI](https://joss.theoj.org/papers/10.21105/joss.05329/status.svg)](https://doi.org/10.21105/joss.05329)
 
 **Qiskit Experiments** is a repository that builds tools for building, running,

--- a/qiskit_experiments/framework/experiment_data.py
+++ b/qiskit_experiments/framework/experiment_data.py
@@ -653,7 +653,7 @@ class ExperimentData:
     @hgp.setter
     def hgp(self, new_hgp: str) -> None:
         """Sets the Hub/Group/Project data from a formatted string"""
-        if re.match(r"\w+/\w+/\w+$", new_hgp) is None:
+        if re.match(r"[^/]*/[^/]*/[^/]*$", new_hgp) is None:
             raise QiskitError("hgp can be only given in a <hub>/<group>/<project> format")
         self._db_data.hub, self._db_data.group, self._db_data.project = new_hgp.split("/")
 

--- a/qiskit_experiments/library/characterization/drag.py
+++ b/qiskit_experiments/library/characterization/drag.py
@@ -166,7 +166,7 @@ class RoughDrag(BaseExperiment, RestlessMixin):
             )
 
             for beta_val in self.experiment_options.betas:
-                beta_val = np.round(beta_val, decimals=6)
+                beta_val = float(np.round(beta_val, decimals=6))
 
                 assigned_circuit = circuit.assign_parameters({beta: beta_val}, inplace=False)
 

--- a/qiskit_experiments/library/tomography/mit_qpt_experiment.py
+++ b/qiskit_experiments/library/tomography/mit_qpt_experiment.py
@@ -78,7 +78,7 @@ class MitigatedProcessTomography(BatchExperiment):
             basis_indices: Optional, a list of basis indices for generating partial
                 tomography measurement data. Each item should be given as a pair of
                 lists of preparation and measurement basis configurations
-                ``([p[0], p[1], ..], m[0], m[1], ...])``, where ``p[i]`` is the
+                ``([p[0], p[1], ...], [m[0], m[1], ...])``, where ``p[i]`` is the
                 preparation basis index, and ``m[i]`` is the measurement basis index
                 for qubit-i. If not specified full tomography for all indices of the
                 preparation and measurement bases will be performed.

--- a/qiskit_experiments/library/tomography/qpt_experiment.py
+++ b/qiskit_experiments/library/tomography/qpt_experiment.py
@@ -81,7 +81,7 @@ class ProcessTomography(TomographyExperiment):
             basis_indices: Optional, a list of basis indices for generating partial
                 tomography measurement data. Each item should be given as a pair of
                 lists of preparation and measurement basis configurations
-                ``([p[0], p[1], ..], m[0], m[1], ...])``, where ``p[i]`` is the
+                ``([p[0], p[1], ...], [m[0], m[1], ...])``, where ``p[i]`` is the
                 preparation basis index, and ``m[i]`` is the measurement basis index
                 for qubit-i. If not specified full tomography for all indices of the
                 preparation and measurement bases will be performed.

--- a/releasenotes/notes/rabi-and-qv-bugfix-34636baee6651af1.yaml
+++ b/releasenotes/notes/rabi-and-qv-bugfix-34636baee6651af1.yaml
@@ -6,3 +6,5 @@ fixes:
   - |
     Resolved an issue that caused QV experiments to fail when executed via `qiskit-ibm-provider` using
     Qiskit Terra for calculating ideal probabilities, instead of Aer.
+  _ |
+    Resolved a serialization issue that affected DRAG experiments with integral beta values specified.

--- a/releasenotes/notes/rabi-and-qv-bugfix-34636baee6651af1.yaml
+++ b/releasenotes/notes/rabi-and-qv-bugfix-34636baee6651af1.yaml
@@ -6,5 +6,5 @@ fixes:
   - |
     Resolved an issue that caused QV experiments to fail when executed via `qiskit-ibm-provider` using
     Qiskit Terra for calculating ideal probabilities, instead of Aer.
-  _ |
+  - |
     Resolved a serialization issue that affected DRAG experiments with integral beta values specified.

--- a/test/base.py
+++ b/test/base.py
@@ -33,7 +33,7 @@ from qiskit_experiments.framework.experiment_data import ExperimentStatus
 from .extended_equality import is_equivalent
 
 # Fail tests that take longer than this
-TEST_TIMEOUT = os.environ.get("TEST_TIMEOUT", 45)
+TEST_TIMEOUT = os.environ.get("TEST_TIMEOUT", 60)
 
 
 class QiskitExperimentsTestCase(QiskitTestCase):

--- a/test/base.py
+++ b/test/base.py
@@ -33,7 +33,7 @@ from qiskit_experiments.framework.experiment_data import ExperimentStatus
 from .extended_equality import is_equivalent
 
 # Fail tests that take longer than this
-TEST_TIMEOUT = os.environ.get("TEST_TIMEOUT", 20)
+TEST_TIMEOUT = os.environ.get("TEST_TIMEOUT", 45)
 
 
 class QiskitExperimentsTestCase(QiskitTestCase):

--- a/test/base.py
+++ b/test/base.py
@@ -17,9 +17,9 @@ import os
 import json
 import pickle
 import warnings
-import fixtures
 from typing import Any, Callable, Optional
 
+import fixtures
 import uncertainties
 from qiskit.test import QiskitTestCase
 from qiskit.utils.deprecation import deprecate_func
@@ -33,7 +33,7 @@ from qiskit_experiments.framework.experiment_data import ExperimentStatus
 from .extended_equality import is_equivalent
 
 # Fail tests that take longer than this
-TEST_TIMEOUT = os.environ.get("TEST_TIMEOUT", 10)
+TEST_TIMEOUT = os.environ.get("TEST_TIMEOUT", 20)
 
 
 class QiskitExperimentsTestCase(QiskitTestCase):

--- a/test/base.py
+++ b/test/base.py
@@ -13,9 +13,11 @@
 Qiskit Experiments test case class
 """
 
+import os
 import json
 import pickle
 import warnings
+import fixtures
 from typing import Any, Callable, Optional
 
 import uncertainties
@@ -30,9 +32,16 @@ from qiskit_experiments.framework import (
 from qiskit_experiments.framework.experiment_data import ExperimentStatus
 from .extended_equality import is_equivalent
 
+# Fail tests that take longer than this
+TEST_TIMEOUT = os.environ.get("TEST_TIMEOUT", 10)
+
 
 class QiskitExperimentsTestCase(QiskitTestCase):
     """Qiskit Experiments specific extra functionality for test cases."""
+
+    def setUp(self):
+        super().setUp()
+        self.useFixture(fixtures.Timeout(TEST_TIMEOUT, gentle=False))
 
     @classmethod
     def setUpClass(cls):

--- a/test/base.py
+++ b/test/base.py
@@ -41,7 +41,7 @@ class QiskitExperimentsTestCase(QiskitTestCase):
 
     def setUp(self):
         super().setUp()
-        self.useFixture(fixtures.Timeout(TEST_TIMEOUT, gentle=False))
+        self.useFixture(fixtures.Timeout(TEST_TIMEOUT, gentle=True))
 
     @classmethod
     def setUpClass(cls):

--- a/test/database_service/test_db_experiment_data.py
+++ b/test/database_service/test_db_experiment_data.py
@@ -1139,3 +1139,12 @@ class TestDbExperimentData(QiskitExperimentsTestCase):
             for n in range(metadata_size)
         ]
         self.assertTrue(exp_data._metadata_too_large())
+
+    def test_hgp_setter(self):
+        """Tests usage of the hgp setter"""
+        exp_data = ExperimentData()
+        exp_data.hgp = "ibm-q-internal/deployed/default"
+        self.assertEqual("ibm-q-internal/deployed/default", exp_data.hgp)
+        self.assertEqual("ibm-q-internal", exp_data.hub)
+        self.assertEqual("deployed", exp_data.group)
+        self.assertEqual("default", exp_data.project)

--- a/test/library/calibration/test_drag.py
+++ b/test/library/calibration/test_drag.py
@@ -68,7 +68,7 @@ class TestDragEndToEnd(QiskitExperimentsTestCase):
         if betas is not None:
             drag.set_experiment_options(betas=betas)
         if p0_opt:
-            drag.analysis.set_options(p0_opt={"beta": 1.8, "freq": 0.08})
+            drag.analysis.set_options(p0=p0_opt)
 
         expdata = drag.run(backend)
         self.assertExperimentDone(expdata)

--- a/test/library/calibration/test_drag.py
+++ b/test/library/calibration/test_drag.py
@@ -97,11 +97,11 @@ class TestDragEndToEnd(QiskitExperimentsTestCase):
         self.assertEqual(result.quality, "good")
 
     @data(
-        (0.0040, 1.0, 0.00, [1, 3, 5], None, 0.1),  # partial oscillation.
-        (0.0020, 0.5, 0.00, [1, 3, 5], None, 0.5),  # even slower oscillation with amp < 1
-        (0.0040, 0.8, 0.05, [3, 5, 7], None, 0.1),  # constant offset, i.e. lower SNR.
-        (0.0800, 0.9, 0.05, [1, 3, 5], np.linspace(-1, 1, 51), 0.1),  # Beta not in range
-        (0.2000, 0.5, 0.10, [1, 3, 5], np.linspace(-2.5, 2.5, 51), 0.1),  # Max closer to zero
+        (0.0040, 1.0, 0.00, [1, 3, 5], None, 0.2),  # partial oscillation.
+        (0.0020, 0.5, 0.00, [1, 3, 5], None, 1.0),  # even slower oscillation with amp < 1
+        (0.0040, 0.8, 0.05, [3, 5, 7], None, 0.2),  # constant offset, i.e. lower SNR.
+        (0.0800, 0.9, 0.05, [1, 3, 5], np.linspace(-1, 1, 51), 0.2),  # Beta not in range
+        (0.2000, 0.5, 0.10, [1, 3, 5], np.linspace(-2.5, 2.5, 51), 0.2),  # Max closer to zero
     )
     @unpack
     def test_nasty_data(self, freq, amp, offset, reps, betas, tol):
@@ -115,6 +115,7 @@ class TestDragEndToEnd(QiskitExperimentsTestCase):
 
         drag = RoughDrag([0], self.x_plus, betas=betas)
         drag.set_experiment_options(reps=reps)
+        drag.set_run_options(shots=500)
 
         exp_data = drag.run(backend)
         self.assertExperimentDone(exp_data)
@@ -192,7 +193,7 @@ class TestDragCircuits(QiskitExperimentsTestCase):
     def test_circuit_roundtrip_serializable(self):
         """Test circuit serializations for drag experiment."""
         drag = RoughDrag([0], self.x_plus)
-        drag.set_experiment_options(reps=[2, 4, 8])
+        drag.set_experiment_options(reps=[2, 4], betas=[-5, 5])
         drag.backend = FakeWashingtonV2()
         self.assertRoundTripSerializable(drag._transpiled_circuits())
 

--- a/test/library/calibration/test_drag.py
+++ b/test/library/calibration/test_drag.py
@@ -55,6 +55,7 @@ class TestDragEndToEnd(QiskitExperimentsTestCase):
         backend = MockIQBackend(drag_experiment_helper)
 
         drag = RoughDrag([1], self.x_plus)
+        drag.set_run_options(shots=200)
 
         expdata = drag.run(backend)
         self.assertExperimentDone(expdata)
@@ -69,6 +70,7 @@ class TestDragEndToEnd(QiskitExperimentsTestCase):
         drag_experiment_helper.frequency = 0.0044
 
         drag = RoughDrag([0], self.x_plus)
+        drag.set_run_options(shots=200)
         exp_data = drag.run(backend)
         self.assertExperimentDone(exp_data)
         result = exp_data.analysis_results(1)

--- a/test/library/calibration/test_rabi.py
+++ b/test/library/calibration/test_rabi.py
@@ -50,9 +50,10 @@ class TestRabiEndToEnd(QiskitExperimentsTestCase):
     def test_rabi_end_to_end(self):
         """Test the Rabi experiment end to end."""
 
-        test_tol = 0.015
+        test_tol = 0.15
 
         rabi = Rabi([self.qubit], self.sched, backend=self.backend)
+        rabi.set_run_options(shots=200)
         rabi.set_experiment_options(amplitudes=np.linspace(-0.1, 0.1, 21))
         expdata = rabi.run()
         self.assertExperimentDone(expdata)

--- a/test/library/calibration/test_rough_amplitude.py
+++ b/test/library/calibration/test_rough_amplitude.py
@@ -159,6 +159,7 @@ class TestSpecializations(QiskitExperimentsTestCase):
         rabi_ef = EFRoughXSXAmplitudeCal(
             [0], self.cals, amplitudes=np.linspace(-0.1, 0.1, 11), backend=self.backend
         )
+        rabi_ef.set_run_options(shots=200)
         expdata = rabi_ef.run()
         self.assertExperimentDone(expdata)
 

--- a/test/library/calibration/test_rough_amplitude.py
+++ b/test/library/calibration/test_rough_amplitude.py
@@ -84,7 +84,7 @@ class TestRoughAmpCal(QiskitExperimentsTestCase):
 
     def test_circuit_roundtrip_serializable(self):
         """Test round trip JSON serialization"""
-        test_amps = [-0.5, 0, 0.5]
+        test_amps = [-0.5, 0]
         rabi = RoughXSXAmplitudeCal([0], self.cals, amplitudes=test_amps, backend=self.backend)
         self.assertRoundTripSerializable(rabi._transpiled_circuits())
 

--- a/test/library/calibration/test_rough_amplitude.py
+++ b/test/library/calibration/test_rough_amplitude.py
@@ -151,9 +151,9 @@ class TestSpecializations(QiskitExperimentsTestCase):
             self.assertEqual(circ.calibrations["Rabi"][((0,), (amp,))], expected_x12)
 
     def test_ef_update(self):
-        """Tes that we properly update the pulses on the 1<->2 transition."""
+        """Test that we properly update the pulses on the 1<->2 transition."""
 
-        tol = 0.01
+        tol = 0.05
         default_amp = 0.5 / self.backend.rabi_rate_12
 
         rabi_ef = EFRoughXSXAmplitudeCal(
@@ -172,6 +172,7 @@ class TestSpecializations(QiskitExperimentsTestCase):
         self.cals.add_parameter_value(int(4 * 160 / 5), "duration", 0, "x12")
         self.cals.add_parameter_value(int(4 * 160 / 5), "duration", 0, "sx12")
         rabi_ef = EFRoughXSXAmplitudeCal([0], self.cals, amplitudes=np.linspace(-0.1, 0.1, 11))
+        rabi_ef.set_run_options(shots=200)
         expdata = rabi_ef.run(self.backend)
         self.assertExperimentDone(expdata)
 

--- a/test/library/characterization/test_cross_resonance_hamiltonian.py
+++ b/test/library/characterization/test_cross_resonance_hamiltonian.py
@@ -167,7 +167,7 @@ class TestCrossResonanceHamiltonian(QiskitExperimentsTestCase):
     @unpack
     def test_integration(self, ix, iy, iz, zx, zy, zz):
         """Integration test for Hamiltonian tomography."""
-        delta = 6e4
+        delta = 3e4
 
         dt = 0.222e-9
         sigma = 64
@@ -197,7 +197,6 @@ class TestCrossResonanceHamiltonian(QiskitExperimentsTestCase):
                 SimulatableCRGate, hamiltonian=hamiltonian, sigma=sigma, dt=dt
             ),
         )
-        expr.set_run_options(shots=500)
         expr.backend = backend
 
         exp_data = expr.run()

--- a/test/library/characterization/test_cross_resonance_hamiltonian.py
+++ b/test/library/characterization/test_cross_resonance_hamiltonian.py
@@ -197,7 +197,7 @@ class TestCrossResonanceHamiltonian(QiskitExperimentsTestCase):
                 SimulatableCRGate, hamiltonian=hamiltonian, sigma=sigma, dt=dt
             ),
         )
-        expr.set_run_options(shots=200)
+        expr.set_run_options(shots=500)
         expr.backend = backend
 
         exp_data = expr.run()

--- a/test/library/characterization/test_cross_resonance_hamiltonian.py
+++ b/test/library/characterization/test_cross_resonance_hamiltonian.py
@@ -167,7 +167,7 @@ class TestCrossResonanceHamiltonian(QiskitExperimentsTestCase):
     @unpack
     def test_integration(self, ix, iy, iz, zx, zy, zz):
         """Integration test for Hamiltonian tomography."""
-        delta = 3e4
+        delta = 6e4
 
         dt = 0.222e-9
         sigma = 64
@@ -192,11 +192,12 @@ class TestCrossResonanceHamiltonian(QiskitExperimentsTestCase):
         expr = cr_hamiltonian.CrossResonanceHamiltonian(
             physical_qubits=(0, 1),
             sigma=sigma,
-            # A hack to avoild local function in pickle, i.e. in transpile.
+            # A hack to avoid local function in pickle, i.e. in transpile.
             cr_gate=functools.partial(
                 SimulatableCRGate, hamiltonian=hamiltonian, sigma=sigma, dt=dt
             ),
         )
+        expr.set_run_options(shots=200)
         expr.backend = backend
 
         exp_data = expr.run()

--- a/test/library/characterization/test_qubit_spectroscopy.py
+++ b/test/library/characterization/test_qubit_spectroscopy.py
@@ -160,7 +160,7 @@ class TestQubitSpectroscopy(QiskitExperimentsTestCase):
 
     def test_roundtrip_serializable(self):
         """Test round trip JSON serialization"""
-        exp = QubitSpectroscopy([1], np.linspace(int(100e6), int(150e6), int(20e6)))
+        exp = QubitSpectroscopy([1], np.linspace(int(100e6), int(150e6), 4))
         # Checking serialization of the experiment
         self.assertRoundTripSerializable(exp)
 

--- a/test/library/characterization/test_qubit_spectroscopy.py
+++ b/test/library/characterization/test_qubit_spectroscopy.py
@@ -270,7 +270,9 @@ class TestQubitSpectroscopy(QiskitExperimentsTestCase):
         par_experiment = ParallelExperiment(
             exp_list, flatten_results=False, backend=parallel_backend
         )
-        par_experiment.set_run_options(meas_level=MeasLevel.KERNELED, meas_return="single")
+        par_experiment.set_run_options(
+            meas_level=MeasLevel.KERNELED, meas_return="single", shots=20
+        )
 
         par_data = par_experiment.run()
         self.assertExperimentDone(par_data)
@@ -288,7 +290,7 @@ class TestQubitSpectroscopy(QiskitExperimentsTestCase):
         backend = FakeWashingtonV2()
         qubit = 1
         freq01 = BackendData(backend).drive_freqs[qubit]
-        frequencies = np.linspace(freq01 - 10.0e6, freq01 + 10.0e6, 21)
+        frequencies = np.linspace(freq01 - 10.0e6, freq01 + 10.0e6, 3)
         exp = QubitSpectroscopy([1], frequencies, backend=backend)
         # Checking serialization of the experiment
         self.assertRoundTripSerializable(exp._transpiled_circuits())

--- a/test/library/characterization/test_readout_angle.py
+++ b/test/library/characterization/test_readout_angle.py
@@ -36,7 +36,7 @@ class TestReadoutAngle(QiskitExperimentsTestCase):
             MockIQReadoutAngleHelper(iq_cluster_centers=[((-3.0, 3.0), (5.0, 5.0))]),
         )
         exp = ReadoutAngle([0])
-        expdata = exp.run(backend, shots=100000)
+        expdata = exp.run(backend, shots=10000)
         self.assertExperimentDone(expdata)
         res = expdata.analysis_results(0)
         self.assertAlmostEqual(res.value % (2 * np.pi), np.pi / 2, places=2)
@@ -45,7 +45,7 @@ class TestReadoutAngle(QiskitExperimentsTestCase):
             MockIQReadoutAngleHelper(iq_cluster_centers=[((0, -3.0), (5.0, 5.0))]),
         )
         exp = ReadoutAngle([0])
-        expdata = exp.run(backend, shots=100000)
+        expdata = exp.run(backend, shots=10000)
         self.assertExperimentDone(expdata)
         res = expdata.analysis_results(0)
         self.assertAlmostEqual(res.value % (2 * np.pi), 15 * np.pi / 8, places=2)

--- a/test/library/characterization/test_resonator_spectroscopy.py
+++ b/test/library/characterization/test_resonator_spectroscopy.py
@@ -158,7 +158,7 @@ class TestResonatorSpectroscopy(QiskitExperimentsTestCase):
             ),
         )
         res_freq = BackendData(backend).meas_freqs[qubit]
-        frequencies = np.linspace(res_freq - 20e6, res_freq + 20e6, 51)
+        frequencies = np.linspace(res_freq - 20e6, res_freq + 20e6, 3)
         exp = ResonatorSpectroscopy([qubit], backend=backend, frequencies=frequencies)
         self.assertRoundTripSerializable(exp._transpiled_circuits())
 

--- a/test/library/characterization/test_resonator_spectroscopy.py
+++ b/test/library/characterization/test_resonator_spectroscopy.py
@@ -134,14 +134,14 @@ class TestResonatorSpectroscopy(QiskitExperimentsTestCase):
 
     def test_experiment_config(self):
         """Test converting to and from config works"""
-        exp = ResonatorSpectroscopy([1], frequencies=np.linspace(100, 150, 20) * 1e6)
+        exp = ResonatorSpectroscopy([1], frequencies=np.linspace(100, 150, 4) * 1e6)
         loaded_exp = ResonatorSpectroscopy.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
         self.assertEqualExtended(exp, loaded_exp)
 
     def test_roundtrip_serializable(self):
         """Test round trip JSON serialization"""
-        exp = ResonatorSpectroscopy([1], frequencies=np.linspace(int(100e6), int(150e6), int(20e6)))
+        exp = ResonatorSpectroscopy([1], frequencies=np.linspace(int(100e6), int(150e6), 4))
         self.assertRoundTripSerializable(exp)
 
     def test_circuit_roundtrip_serializable(self):
@@ -177,7 +177,7 @@ class TestResonatorSpectroscopy(QiskitExperimentsTestCase):
 
         res_freq = BackendData(backend).meas_freqs[qubit]
 
-        frequencies = np.linspace(res_freq - 20e6, res_freq + 20e6, 51)
+        frequencies = np.linspace(res_freq - 20e6, res_freq + 20e6, 11)
         exp = ResonatorSpectroscopy([qubit], backend=backend, frequencies=frequencies)
 
         expdata = exp.run(backend)
@@ -226,8 +226,8 @@ class TestResonatorSpectroscopy(QiskitExperimentsTestCase):
         res_freq1 = backend_data.meas_freqs[qubit1]
         res_freq2 = backend_data.meas_freqs[qubit2]
 
-        frequencies1 = np.linspace(res_freq1 - 20e6, res_freq1 + 20e6, 51)
-        frequencies2 = np.linspace(res_freq2 - 20e6, res_freq2 + 20e6, 53)
+        frequencies1 = np.linspace(res_freq1 - 20e6, res_freq1 + 20e6, 11)
+        frequencies2 = np.linspace(res_freq2 - 20e6, res_freq2 + 20e6, 13)
 
         res_spect1 = ResonatorSpectroscopy(
             [qubit1], backend=parallel_backend, frequencies=frequencies1

--- a/test/library/characterization/test_t1.py
+++ b/test/library/characterization/test_t1.py
@@ -311,7 +311,7 @@ class TestT1(QiskitExperimentsTestCase):
 
     def test_roundtrip_serializable(self):
         """Test round trip JSON serialization"""
-        exp = T1([0], [1, 2, 3, 4, 5])
+        exp = T1([0], [1, 2])
         self.assertRoundTripSerializable(exp)
 
     def test_circuit_roundtrip_serializable(self):

--- a/test/library/characterization/test_t2hahn.py
+++ b/test/library/characterization/test_t2hahn.py
@@ -179,7 +179,7 @@ class TestT2Hahn(QiskitExperimentsTestCase):
     def test_roundtrip_serializable(self):
         """Test round trip JSON serialization"""
 
-        delays0 = list(range(1, 60, 2))
+        delays0 = list(range(1, 60, 20))
 
         exp = T2Hahn([0], delays0)
         self.assertRoundTripSerializable(exp)

--- a/test/library/characterization/test_t2hahn.py
+++ b/test/library/characterization/test_t2hahn.py
@@ -205,7 +205,7 @@ class TestT2Hahn(QiskitExperimentsTestCase):
 
     def test_circuit_roundtrip_serializable(self):
         """Test round trip JSON serialization"""
-        delays0 = list(range(1, 60, 2))
+        delays0 = list(range(1, 60, 20))
         # backend is needed for serialization of the delays in the metadata of the experiment.
         backend = FakeVigoV2()
         exp = T2Hahn([0], delays0, backend=backend)

--- a/test/library/characterization/test_t2ramsey.py
+++ b/test/library/characterization/test_t2ramsey.py
@@ -228,7 +228,7 @@ class TestT2Ramsey(QiskitExperimentsTestCase):
     def test_circuit_roundtrip_serializable(self):
         """Test round trip JSON serialization"""
         backend = FakeVigoV2()
-        exp = T2Ramsey([0], [1, 2, 3, 4, 5], backend=backend)
+        exp = T2Ramsey([0], [1, 2], backend=backend)
         self.assertRoundTripSerializable(exp._transpiled_circuits())
 
     def test_analysis_config(self):

--- a/test/library/characterization/test_t2ramsey.py
+++ b/test/library/characterization/test_t2ramsey.py
@@ -222,7 +222,7 @@ class TestT2Ramsey(QiskitExperimentsTestCase):
 
     def test_roundtrip_serializable(self):
         """Test round trip JSON serialization"""
-        exp = T2Ramsey([0], [1, 2, 3, 4, 5])
+        exp = T2Ramsey([0], [1, 2])
         self.assertRoundTripSerializable(exp)
 
     def test_circuit_roundtrip_serializable(self):

--- a/test/library/quantum_volume/test_qv.py
+++ b/test/library/quantum_volume/test_qv.py
@@ -275,6 +275,6 @@ class TestQuantumVolume(QiskitExperimentsTestCase):
 
     def test_circuit_roundtrip_serializable(self):
         """Test expdata round trip JSON serialization"""
-        num_of_qubits = 4
+        num_of_qubits = 3
         qv_exp = QuantumVolume(range(num_of_qubits), seed=SEED)
         self.assertRoundTripSerializable(qv_exp._transpiled_circuits())

--- a/test/library/randomized_benchmarking/test_interleaved_rb.py
+++ b/test/library/randomized_benchmarking/test_interleaved_rb.py
@@ -72,14 +72,14 @@ class TestInterleavedRB(QiskitExperimentsTestCase, RBTestMixin):
     def test_roundtrip_serializable(self):
         """Test round trip JSON serialization"""
         exp = rb.InterleavedRB(
-            interleaved_element=SXGate(), physical_qubits=(0,), lengths=[10, 20, 30], seed=123
+            interleaved_element=SXGate(), physical_qubits=(0,), lengths=[1, 3], seed=123
         )
         self.assertRoundTripSerializable(exp)
 
     def test_circuit_roundtrip_serializable(self):
         """Test circuits round trip JSON serialization"""
         exp = rb.InterleavedRB(
-            interleaved_element=SXGate(), physical_qubits=(0,), lengths=[10, 20, 30], seed=123
+            interleaved_element=SXGate(), physical_qubits=(0,), lengths=[1, 3], seed=123
         )
         self.assertRoundTripSerializable(exp._transpiled_circuits())
 

--- a/test/library/randomized_benchmarking/test_interleaved_rb.py
+++ b/test/library/randomized_benchmarking/test_interleaved_rb.py
@@ -276,6 +276,7 @@ class TestInterleavedRB(QiskitExperimentsTestCase, RBTestMixin):
             lengths=[3],
             num_samples=4,
             backend=my_backend,
+            seed=1234,
         )
         transpiled = exp._transpiled_circuits()
         for qc in transpiled:

--- a/test/library/randomized_benchmarking/test_standard_rb.py
+++ b/test/library/randomized_benchmarking/test_standard_rb.py
@@ -57,12 +57,12 @@ class TestStandardRB(QiskitExperimentsTestCase, RBTestMixin):
 
     def test_roundtrip_serializable(self):
         """Test round trip JSON serialization"""
-        exp = rb.StandardRB(physical_qubits=(0,), lengths=[10, 20, 30], seed=123)
+        exp = rb.StandardRB(physical_qubits=(0,), lengths=[1,3], seed=123)
         self.assertRoundTripSerializable(exp)
 
     def test_circuit_roundtrip_serializable(self):
         """Test circuits round trip JSON serialization"""
-        exp = rb.StandardRB(physical_qubits=(0,), lengths=[10, 20, 30], seed=123)
+        exp = rb.StandardRB(physical_qubits=(0,), lengths=[1,3], seed=123)
         self.assertRoundTripSerializable(exp._transpiled_circuits())
 
     def test_analysis_config(self):

--- a/test/library/randomized_benchmarking/test_standard_rb.py
+++ b/test/library/randomized_benchmarking/test_standard_rb.py
@@ -57,12 +57,12 @@ class TestStandardRB(QiskitExperimentsTestCase, RBTestMixin):
 
     def test_roundtrip_serializable(self):
         """Test round trip JSON serialization"""
-        exp = rb.StandardRB(physical_qubits=(0,), lengths=[1,3], seed=123)
+        exp = rb.StandardRB(physical_qubits=(0,), lengths=[1, 3], seed=123)
         self.assertRoundTripSerializable(exp)
 
     def test_circuit_roundtrip_serializable(self):
         """Test circuits round trip JSON serialization"""
-        exp = rb.StandardRB(physical_qubits=(0,), lengths=[1,3], seed=123)
+        exp = rb.StandardRB(physical_qubits=(0,), lengths=[1, 3], seed=123)
         self.assertRoundTripSerializable(exp._transpiled_circuits())
 
     def test_analysis_config(self):

--- a/test/library/tomography/test_process_tomography.py
+++ b/test/library/tomography/test_process_tomography.py
@@ -103,7 +103,7 @@ class TestProcessTomography(QiskitExperimentsTestCase):
         circ.s(0)
         circ.cx(0, 1)
 
-        exp = ProcessTomography(circ)
+        exp = ProcessTomography(circ, preparation_indices=[0], measurement_indices=[0])
         self.assertRoundTripSerializable(exp._transpiled_circuits())
 
     def test_cvxpy_gaussian_lstsq_cx(self):

--- a/tox.ini
+++ b/tox.ini
@@ -105,6 +105,3 @@ skip_install = true
 deps =
 allowlist_externals = rm
 commands = rm -rf {toxinidir}/docs/stubs/ {toxinidir}/docs/_build
-
-[testenv:stestr-clean]
-commands = stestr history remove all

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,16 @@ passenv =
   QISKIT_IBM_*
 commands = stestr run {posargs}
 
+[testenv:cover]
+basepython = python3
+setenv =
+    {[testenv]setenv}
+    PYTHON=coverage3 run --source qiskit_experiments --parallel-mode
+commands =
+    stestr run {posargs}
+    coverage3 combine
+    coverage3 lcov
+
 [testenv:terra-main]
 usedevelop = True
 install_command = pip install -U {opts} {packages}

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,9 @@ minversion = 3.3.0
 envlist = py311,py310,py39,py38,lint
 isolated_build = true
 
+[stestr]
+group_regex=([^\.]+\.)+
+
 [testenv]
 usedevelop = True
 install_command = pip install -c{toxinidir}/constraints.txt -U {opts} {packages}
@@ -105,3 +108,4 @@ skip_install = true
 deps =
 allowlist_externals = rm
 commands = rm -rf {toxinidir}/docs/stubs/ {toxinidir}/docs/_build
+

--- a/tox.ini
+++ b/tox.ini
@@ -3,9 +3,6 @@ minversion = 3.3.0
 envlist = py311,py310,py39,py38,lint
 isolated_build = true
 
-[stestr]
-group_regex=([^\.]+\.)+
-
 [testenv]
 usedevelop = True
 install_command = pip install -c{toxinidir}/constraints.txt -U {opts} {packages}

--- a/tox.ini
+++ b/tox.ini
@@ -19,16 +19,6 @@ passenv =
   QISKIT_IBM_*
 commands = stestr run {posargs}
 
-[testenv:cover]
-basepython = python3
-setenv =
-    {[testenv]setenv}
-    PYTHON=coverage3 run --source qiskit_experiments --parallel-mode
-commands =
-    stestr run {posargs}
-    coverage3 combine
-    coverage3 lcov
-
 [testenv:terra-main]
 usedevelop = True
 install_command = pip install -U {opts} {packages}

--- a/tox.ini
+++ b/tox.ini
@@ -106,3 +106,5 @@ deps =
 allowlist_externals = rm
 commands = rm -rf {toxinidir}/docs/stubs/ {toxinidir}/docs/_build
 
+[testenv:stestr-clean]
+commands = stestr history remove all


### PR DESCRIPTION
### Summary

This PR does a few things to make tests run faster:

- [x] Only test on the lowest and highest supported python versions
- [x] Set MacOS build options to be the same as the other OSes (and remove coverage)
- [x] Add `.stestr` to the cache as suggested by @mtreinish. This doesn't seem to improve the Ubuntu and Windows runtimes but significantly improves MacOS's.
- [x] Group tests in stestr by class name. This might avoid large parallelized tests being run on multiple workers simultaneously and slowing each test down.
- [x] Fail a test automatically if it takes longer than 60 seconds (hopefully this can be shortened in the future, but for now it mostly prevents a very long test from being added)
- [x] Shorten long tests by decreasing shots and generating smaller circuits where the size isn't relevant (such as the roundtrip serialization tests)
- [x] Also fixes a bug in the DRAG experiment where integer `beta` values caused a serialization error.

Test are currently 20-40 minutes for Windows/Ubuntu and 50+ minutes for MacOS. With this PR, all tests go down to ~10 minutes.