### PR TITLE
Avoid copy of full circuit in tomography experiment generation

### DIFF
--- a/qiskit_experiments/library/tomography/tomography_experiment.py
+++ b/qiskit_experiments/library/tomography/tomography_experiment.py
@@ -214,7 +214,7 @@ class TomographyExperiment(BaseExperiment):
             # Add target circuit
             # Have to use compose since circuit.to_instruction has a bug
             # when circuit contains classical registers and conditionals
-            circ = circ.compose(self._circuit, circ_qubits, circ_clbits)
+            circ.compose(self._circuit, circ_qubits, circ_clbits, inplace=True)
 
             # Add tomography measurement
             if meas_element:


### PR DESCRIPTION
### Summary

Avoid a copy of the tomography circuit by using an inplace composition.

### Details and comments

Avoid a copy of the tomography circuit by using an inplace composition. The inplace operation improves performance of the tomograph experiments.
