### PR TITLE
Fix small error in test_multi_state_discrimination pulse usage

### DIFF
--- a/test/library/characterization/test_multi_state_discrimination.py
+++ b/test/library/characterization/test_multi_state_discrimination.py
@@ -63,11 +63,10 @@ class TestMultiStateDiscrimination(QiskitExperimentsTestCase):
         amp_x = pulse_x.amp
         dur_x = pulse_x.duration
         sigma_x = pulse_x.sigma
-        beta_x = pulse_x.beta
         with pulse.build(name="x12") as x12:
             pulse.shift_frequency(anharm, d0)
             pulse.play(
-                pulse.Gaussian(dur_x, amp_x * self.backend.rabi_rate_12, sigma_x, beta_x), d0
+                pulse.Gaussian(dur_x, amp_x * self.backend.rabi_rate_12, sigma_x), d0
             )
             pulse.shift_frequency(-anharm, d0)
 


### PR DESCRIPTION
### Summary

A small error in test_multi_state_discrimination pulse usage was fixed.

### Details and comments

A Drag pulse's parameters were being copied into a Gaussian pulse with the beta value passed as the Gaussian angle parameter.