### PR TITLE
Improve performance of RB circuit generation

### DIFF
--- a/qiskit_experiments/library/randomized_benchmarking/clifford_utils.py
+++ b/qiskit_experiments/library/randomized_benchmarking/clifford_utils.py
@@ -36,7 +36,7 @@ _DATA_FOLDER = os.path.join(os.path.dirname(__file__), "data")
 
 _CLIFFORD_COMPOSE_1Q = np.load(f"{_DATA_FOLDER}/clifford_compose_1q.npz")["table"]
 _CLIFFORD_INVERSE_1Q = np.load(f"{_DATA_FOLDER}/clifford_inverse_1q.npz")["table"]
-_CLIFFORD_COMPOSE_2Q = scipy.sparse.load_npz(f"{_DATA_FOLDER}/clifford_compose_2q_sparse.npz")
+_CLIFFORD_COMPOSE_2Q = scipy.sparse.lil_matrix(scipy.sparse.load_npz(f"{_DATA_FOLDER}/clifford_compose_2q_sparse.npz"))
 _CLIFFORD_INVERSE_2Q = np.load(f"{_DATA_FOLDER}/clifford_inverse_2q.npz")["table"]
 
 

--- a/qiskit_experiments/library/randomized_benchmarking/clifford_utils.py
+++ b/qiskit_experiments/library/randomized_benchmarking/clifford_utils.py
@@ -36,7 +36,9 @@ _DATA_FOLDER = os.path.join(os.path.dirname(__file__), "data")
 
 _CLIFFORD_COMPOSE_1Q = np.load(f"{_DATA_FOLDER}/clifford_compose_1q.npz")["table"]
 _CLIFFORD_INVERSE_1Q = np.load(f"{_DATA_FOLDER}/clifford_inverse_1q.npz")["table"]
-_CLIFFORD_COMPOSE_2Q = scipy.sparse.lil_matrix(scipy.sparse.load_npz(f"{_DATA_FOLDER}/clifford_compose_2q_sparse.npz"))
+_CLIFFORD_COMPOSE_2Q = scipy.sparse.lil_matrix(
+    scipy.sparse.load_npz(f"{_DATA_FOLDER}/clifford_compose_2q_sparse.npz")
+)
 _CLIFFORD_INVERSE_2Q = np.load(f"{_DATA_FOLDER}/clifford_inverse_2q.npz")["table"]
 
 


### PR DESCRIPTION
### Summary

The circuit generation for RB experiments is slow due to the use of indexing on sparse matrices (`_CLIFFORD_COMPOSE_2Q` from `qiskit_experiments.library.randomized_benchmarking.clifford_utils`). Since indexing is the only operation used on `_CLIFFORD_COMPOSE_2Q` we can improve performance by using the `lil_matrix` format.

### Details and comments

Improve performance of RB circuit generation by changing the format of `_CLIFFORD_COMPOSE_2Q` to `lil_matrix`.

Micro benchmark:
```
import scipy.sparse
from qiskit_experiments.library.randomized_benchmarking.clifford_utils import _CLIFFORD_COMPOSE_2Q

_CLIFFORD_COMPOSE_2Q_lil =  scipy.sparse.lil_matrix(_CLIFFORD_COMPOSE_2Q)

%timeit _CLIFFORD_COMPOSE_2Q[2,3]
%timeit _CLIFFORD_COMPOSE_2Q_lil[2,3]
```
Result:
```
29.4 µs ± 4.01 µs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
2.64 µs ± 777 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```

Application benchmark:
```
import time
import qiskit
from qiskit_experiments.library import InterleavedRB

gate=qiskit.circuit.library.CXGate()
rb=InterleavedRB(gate, physical_qubits= (0,1),lengths= [1,10,50,100,200], num_samples= 10)

t0=time.time()
c=rb.circuits()
dt=time.time()-t0
```
results in a speedup from 2.1419544219970703 to 1.154689073562622 seconds.



### PR checklist (delete when all criteria are met)

- [x] I have read the contributing guide `CONTRIBUTING.md`.
- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have added a release note file using `reno` if this change needs to be documented in the release notes. (no release note required)
