### PR TITLE
Backport #1264

### DIFF
--- a/test/library/characterization/test_t1.py
+++ b/test/library/characterization/test_t1.py
@@ -208,6 +208,7 @@ class TestT1(QiskitExperimentsTestCase):
             self.assertEqual(sub_res.quality, "good")
             self.assertAlmostEqual(sub_res.value.n, t1[qb], delta=3)
 
+<<<<<<< HEAD
         res.service = IBMExperimentService(local=True, local_save=False)
         res.save()
         loaded_data = ExperimentData.load(res.experiment_id, res.service)
@@ -248,6 +249,8 @@ class TestT1(QiskitExperimentsTestCase):
         self.assertAlmostEqual(sub_res[0].value.n, t1[0], delta=3)
         self.assertEqual(sub_res[1].quality, "bad")
 
+=======
+>>>>>>> e9abdc4 (Removed test_t1_parallel_different_analysis_options (#1264))
     def test_t1_analysis(self):
         """
         Test T1Analysis

--- a/test/library/characterization/test_t1.py
+++ b/test/library/characterization/test_t1.py
@@ -208,7 +208,6 @@ class TestT1(QiskitExperimentsTestCase):
             self.assertEqual(sub_res.quality, "good")
             self.assertAlmostEqual(sub_res.value.n, t1[qb], delta=3)
 
-<<<<<<< HEAD
         res.service = IBMExperimentService(local=True, local_save=False)
         res.save()
         loaded_data = ExperimentData.load(res.experiment_id, res.service)
@@ -218,39 +217,6 @@ class TestT1(QiskitExperimentsTestCase):
             sub_loaded = loaded_data.child_data(i).analysis_results("T1")
             self.assertEqual(repr(sub_res), repr(sub_loaded))
 
-    def test_t1_parallel_different_analysis_options(self):
-        """
-        Test parallel experiments of T1 using a simulator, for the case where
-        the sub-experiments have different analysis options
-        """
-
-        t1 = [25, 25]
-        t2 = [value / 2 for value in t1]
-
-        backend = NoisyDelayAerBackend(t1, t2)
-
-        delays = list(range(1, 40, 3))
-
-        exp0 = T1([0], delays)
-        exp0.analysis.set_options(p0={"tau": 30})
-
-        exp1 = T1([1], delays)
-        exp1.analysis.set_options(p0={"tau": 1000000})
-
-        par_exp = ParallelExperiment([exp0, exp1])
-        res = par_exp.run(backend=backend, seed_simulator=4)
-        self.assertExperimentDone(res)
-
-        sub_res = []
-        for i in range(2):
-            sub_res.append(res.child_data(i).analysis_results("T1"))
-
-        self.assertEqual(sub_res[0].quality, "good")
-        self.assertAlmostEqual(sub_res[0].value.n, t1[0], delta=3)
-        self.assertEqual(sub_res[1].quality, "bad")
-
-=======
->>>>>>> e9abdc4 (Removed test_t1_parallel_different_analysis_options (#1264))
     def test_t1_analysis(self):
         """
         Test T1Analysis


### PR DESCRIPTION
#1264 fails to merge to 0.5 (see #1265 failure) because of a conflict with #1178, which was merged to main but not to 0.5.
This PR fixes the conflict by merging manually to 0.5.
Changes of #1178 are not imported to 0.5 in this PR.
