### PR TITLE
Address timing dependence in ExperimentData.add_jobs test

### DIFF
--- a/test/database_service/test_db_experiment_data.py
+++ b/test/database_service/test_db_experiment_data.py
@@ -137,7 +137,13 @@ class TestDbExperimentData(QiskitExperimentsTestCase):
         self.assertExperimentDone(exp_data)
         exp_data.add_jobs(jobs)
         self.assertExperimentDone(exp_data)
-        self.assertEqual(expected, [sdata["counts"] for sdata in sorted(exp_data.data(), key=lambda x: x["metadata"]["label"])])
+        self.assertEqual(
+            expected,
+            [
+                sdata["counts"]
+                for sdata in sorted(exp_data.data(), key=lambda x: x["metadata"]["label"])
+            ],
+        )
         self.assertIn(a_job.job_id(), exp_data.job_ids)
 
     def test_add_data_job_callback(self):


### PR DESCRIPTION
Previously, the test `test_add_data_job` called `add_jobs` with two jobs and then tested that the results from `ExperimentData.data()` matched the results of the first job concatenated with the second. `ExperimentData` uses threads to handle tracking jobs. Even though these jobs are dummy jobs that take no time, `ExperimentData`  would occasionally add the results from the second job before the first and then fail the results comparison. With this change, a label is attached to each result and then the results are sorted based on the label before testing against the expected results.

Closes #1044