### PR TITLE
Update `HamiltonianGate` path

### DIFF
--- a/releasenotes/notes/0.3/cleanup-cr-hamiltonian-experiment-7f47c51d26941f16.yaml
+++ b/releasenotes/notes/0.3/cleanup-cr-hamiltonian-experiment-7f47c51d26941f16.yaml
@@ -6,5 +6,5 @@ upgrade:
     setting backend for just checking experiment sequence. The sequence with actual parameters
     is generated after the backend is set. In addition, now experiments can take ``cr_gate``
     in the constractor which is ``Gate`` type subclass taking a single parameter (flat-top width).
-    If one inputs a :class:`~qiskit.extensions.hamiltonian_gate.HamiltonianGate` subclass with
+    If one inputs a :class:`~qiskit.circuit.library.HamiltonianGate` subclass with
     cross resonance Hamiltonian, experiment can be simulated with Aer QASM simulator.

--- a/test/library/characterization/test_cross_resonance_hamiltonian.py
+++ b/test/library/characterization/test_cross_resonance_hamiltonian.py
@@ -21,7 +21,7 @@ import numpy as np
 from ddt import ddt, data, unpack
 from qiskit import QuantumCircuit, pulse, qpy, quantum_info as qi
 from qiskit.providers.fake_provider import FakeBogotaV2
-from qiskit.extensions.hamiltonian_gate import HamiltonianGate
+from qiskit.circuit.library.hamiltonian_gate import HamiltonianGate
 from qiskit_aer import AerSimulator
 from qiskit_experiments.library.characterization import cr_hamiltonian
 


### PR DESCRIPTION
### Summary

After `qiskit.extensions` was deprecated in https://github.com/Qiskit/qiskit/pull/10725, this PR updates the path of `HamiltonianGate` so tests against Qiskit main pass again.
