### PR TITLE
Add Job Splitting Information Methods for Better User Experience

### DIFF
--- a/qiskit_experiments/framework/base_experiment.py
+++ b/qiskit_experiments/framework/base_experiment.py
@@ -277,9 +277,7 @@ class BaseExperiment(ABC, StoreInitArgs):
             backend = self.backend
         self.backend = backend
         # Get max circuits for job splitting
-        max_circuits_option = getattr(self.experiment_options,
-                                      "max_circuits",
-                                      None)
+        max_circuits_option = getattr(self.experiment_options, "max_circuits", None)
         max_circuits_backend = self._backend_data.max_circuits
 
         if max_circuits_option and max_circuits_backend:
@@ -295,19 +293,20 @@ class BaseExperiment(ABC, StoreInitArgs):
         backend.
 
         Args:
-            backend (Backend): The backend for which to get job distribution
-            information.
+            backend: Optional, the backend for which to get job distribution
+            information. If not specified, the experiment must already have a
+            set backend.
 
         Returns:
             dict: A dictionary containing information about job distribution.
-            
+
                 - "Total number of circuits in the experiment": Total number of
                   circuits in the experiment.
-                  
-                - "Maximum number of circuits per job": Maximum number of 
+
+                - "Maximum number of circuits per job": Maximum number of
                   circuits in one job based on backend and experiment settings.
-                  
-                - "Total number of jobs": Number of jobs needed to run this 
+
+                - "Total number of jobs": Number of jobs needed to run this
                   experiment on the currently set backend.
 
         Raises:
@@ -324,35 +323,28 @@ class BaseExperiment(ABC, StoreInitArgs):
         return {
             "Total number of circuits in the experiment": total_circuits,
             "Maximum number of circuits per job": max_circuits,
-            "Total number of jobs": num_jobs
+            "Total number of jobs": num_jobs,
         }
 
-    def _run_jobs(
-            self,
-            circuits: List[QuantumCircuit],
-            backend: Backend = None,
-            **run_options) -> List[Job]:
+    def _run_jobs(self, circuits: List[QuantumCircuit], **run_options) -> List[Job]:
         """Run circuits on backend as 1 or more jobs."""
-        max_circuits = self._max_circuits(backend)
+        max_circuits = self._max_circuits(self.backend)
 
         # Run experiment jobs
         if max_circuits and (len(circuits) > max_circuits):
             # Split jobs for backends that have a maximum job size
             job_circuits = [
-                circuits[i:i + max_circuits] for i in range(0,
-                                                            len(circuits),
-                                                            max_circuits)
+                circuits[i : i + max_circuits] for i in range(0, len(circuits), max_circuits)
             ]
         else:
             # Run as single job
             job_circuits = [circuits]
 
         # Run jobs
-        jobs = [self.backend.run(circs, **run_options) for circs in
-                job_circuits]
+        jobs = [self.backend.run(circs, **run_options) for circs in job_circuits]
 
         return jobs
-    
+
     @abstractmethod
     def circuits(self) -> List[QuantumCircuit]:
         """Return a list of experiment circuits.

--- a/qiskit_experiments/framework/base_experiment.py
+++ b/qiskit_experiments/framework/base_experiment.py
@@ -300,12 +300,15 @@ class BaseExperiment(ABC, StoreInitArgs):
 
         Returns:
             dict: A dictionary containing information about job distribution.
+            
                 - "Total number of circuits in the experiment": Total number of
-                circuits in the experiment.
-                - "Maximum number of circuits": Maximum number of circuits in
-                one Job
-                - "Total number of jobs": Number of jobs needed for
-                distribution.
+                  circuits in the experiment.
+                  
+                - "Maximum number of circuits per job": Maximum number of 
+                  circuits in one job based on backend and experiment settings.
+                  
+                - "Total number of jobs": Number of jobs needed to run this 
+                  experiment on the currently set backend.
 
         Raises:
             QiskitError: if backend is not specified.

--- a/qiskit_experiments/framework/base_experiment.py
+++ b/qiskit_experiments/framework/base_experiment.py
@@ -275,10 +275,9 @@ class BaseExperiment(ABC, StoreInitArgs):
             if self.backend is None:
                 raise QiskitError("A backend must be provided.")
             backend = self.backend
-        self.backend = backend
         # Get max circuits for job splitting
         max_circuits_option = getattr(self.experiment_options, "max_circuits", None)
-        max_circuits_backend = self._backend_data.max_circuits
+        max_circuits_backend = BackendData(backend).max_circuits
 
         if max_circuits_option and max_circuits_backend:
             return min(max_circuits_option, max_circuits_backend)

--- a/releasenotes/notes/circuit-count-method-a095bd74aaa1d2fb.yaml
+++ b/releasenotes/notes/circuit-count-method-a095bd74aaa1d2fb.yaml
@@ -1,27 +1,11 @@
 ---
 features:
   - |
-    Introducing the following methods to :class: `BaseExperiment`
-    -------------------------------------------------------------------
-    :math: `BaseExperiment._max_circuit`: This method will calculate the
-    maximum number of circuits that can be included in a single job.
-    :math:`BaseExperiment.job_info`: This method will give information about
-    job distribution for the experiment on a specific.
-  - |
-    Refactor :math:`BaseExperiment._run_jobs`
-    ----------------------------------------
-    :math:`BaseExperiment._run_jobs`:The existing _run_jobs() method will be 
-    refactored to make use of the _max_circuits() method. This change will
-    enhance code readability and maintainability by segregating the logic
-    related to job distribution from the actual job execution logic.
-  - |
-    Added unit test method to :class:`TestFramework`
-    ---------------------------------------------
-    :math:`TestFramework.test_max_circuits` and
-    :math:`TestFramework.test_job_info` these tests ensure that added methods 
-    functioning correctly.
+    A new method :meth:`BaseExperiment.job_info` has been added that will
+    output the number of jobs the experiment is expected to be split into
+    based on the provided backend.
   - |
     Refer to issue
     `#1247 https://github.com/Qiskit-Extensions/qiskit-experiments/issues/1247`
     for more details.
-
+    

--- a/releasenotes/notes/circuit-count-method-a095bd74aaa1d2fb.yaml
+++ b/releasenotes/notes/circuit-count-method-a095bd74aaa1d2fb.yaml
@@ -1,0 +1,27 @@
+---
+features:
+  - |
+    Introducing the following methods to :class: `BaseExperiment`
+    -------------------------------------------------------------------
+    :math: `BaseExperiment._max_circuit`: This method will calculate the
+    maximum number of circuits that can be included in a single job.
+    :math:`BaseExperiment.job_info`: This method will give information about
+    job distribution for the experiment on a specific.
+  - |
+    Refactor :math:`BaseExperiment._run_jobs`
+    ----------------------------------------
+    :math:`BaseExperiment._run_jobs`:The existing _run_jobs() method will be 
+    refactored to make use of the _max_circuits() method. This change will
+    enhance code readability and maintainability by segregating the logic
+    related to job distribution from the actual job execution logic.
+  - |
+    Added unit test method to :class:`TestFramework`
+    ---------------------------------------------
+    :math:`TestFramework.test_max_circuits` and
+    :math:`TestFramework.test_job_info` these tests ensure that added methods 
+    functioning correctly.
+  - |
+    Refer to issue
+    `#1247 https://github.com/Qiskit-Extensions/qiskit-experiments/issues/1247`
+    for more details.
+

--- a/test/framework/test_framework.py
+++ b/test/framework/test_framework.py
@@ -292,13 +292,11 @@ class TestFramework(QiskitExperimentsTestCase):
         # set backend
         if backend is None:
             if exp.backend is None:
-                exp.assertRaise(QiskitError)
+                self.assertRaises(QiskitError)
             backend = exp.backend
         exp.backend = backend
         # Get max circuits for job splitting
-        max_circuits_option = getattr(exp.experiment_options,
-                                      "max_circuits",
-                                      None)
+        max_circuits_option = getattr(exp.experiment_options, "max_circuits", None)
         max_circuits_backend = exp._backend_data.max_circuits
         if max_circuits_option and max_circuits_backend:
             result = min(max_circuits_option, max_circuits_backend)
@@ -308,7 +306,6 @@ class TestFramework(QiskitExperimentsTestCase):
             result = max_circuits_backend
 
         self.assertEqual(exp._max_circuits(backend=backend), result)
-
 
     @ddt.data(None, 1, 10, 100)
     def test_job_info(self, max_experiments):
@@ -339,7 +336,7 @@ class TestFramework(QiskitExperimentsTestCase):
         job_info = {
             "Total number of circuits in the experiment": num_circuits,
             "Maximum number of circuits per job": max_experiments,
-            "Total number of jobs": num_jobs
+            "Total number of jobs": num_jobs,
         }
 
         self.assertEqual(exp.job_info(backend=backend), job_info)

--- a/test/framework/test_framework.py
+++ b/test/framework/test_framework.py
@@ -267,3 +267,79 @@ class TestFramework(QiskitExperimentsTestCase):
         res = expdata.analysis_results()
         self.assertEqual(len(res), 0)
         self.assertEqual(expdata.analysis_status(), AnalysisStatus.CANCELLED)
+
+    @ddt.data(1, 10, 100)
+    def test_max_circuits(self, max_experiments):
+        """Test running experiment with max_circuits"""
+
+        num_circuits = 10
+
+        class MyExp(BaseExperiment):
+            """Some arbitrary experiment"""
+
+            def __init__(self, physical_qubits):
+                super().__init__(physical_qubits)
+
+            def circuits(self):
+                """Generate fake circuits"""
+                qc = QuantumCircuit(1)
+                qc.measure_all()
+                return num_circuits * [qc]
+
+        backend = FakeBackend(max_experiments=max_experiments)
+        exp = MyExp([0])
+
+        # set backend
+        if backend is None:
+            if exp.backend is None:
+                exp.assertRaise(QiskitError)
+            backend = exp.backend
+        exp.backend = backend
+        # Get max circuits for job splitting
+        max_circuits_option = getattr(exp.experiment_options,
+                                      "max_circuits",
+                                      None)
+        max_circuits_backend = exp._backend_data.max_circuits
+        if max_circuits_option and max_circuits_backend:
+            result = min(max_circuits_option, max_circuits_backend)
+        elif max_circuits_option:
+            result = max_circuits_option
+        else:
+            result = max_circuits_backend
+
+        self.assertEqual(exp._max_circuits(backend=backend), result)
+
+
+    @ddt.data(None, 1, 10, 100)
+    def test_job_info(self, max_experiments):
+        """Test job_info for specific backend"""
+
+        num_circuits = 10
+
+        class MyExp(BaseExperiment):
+            """Some arbitrary experiment"""
+
+            def __init__(self, physical_qubits):
+                super().__init__(physical_qubits)
+
+            def circuits(self):
+                """Generate fake circuits"""
+                qc = QuantumCircuit(1)
+                qc.measure_all()
+                return num_circuits * [qc]
+
+        backend = FakeBackend(max_experiments=max_experiments)
+        exp = MyExp([0])
+
+        if max_experiments is None:
+            num_jobs = 1
+        else:
+            num_jobs = (num_circuits + max_experiments - 1) // max_experiments
+
+        job_info = {
+            "Total number of circuits in the experiment": num_circuits,
+            "Maximum number of circuits per job": max_experiments,
+            "Total number of jobs": num_jobs
+        }
+
+        self.assertEqual(exp.job_info(backend=backend), job_info)

--- a/test/framework/test_framework.py
+++ b/test/framework/test_framework.py
@@ -268,7 +268,7 @@ class TestFramework(QiskitExperimentsTestCase):
         self.assertEqual(len(res), 0)
         self.assertEqual(expdata.analysis_status(), AnalysisStatus.CANCELLED)
 
-    @ddt.data(1, 10, 100)
+    @ddt.data(None, 1, 10, 100)
     def test_max_circuits(self, max_experiments):
         """Test running experiment with max_circuits"""
 


### PR DESCRIPTION
 This PR aims to solve issue #1247 als the changes are similar to PR #1248
### Summary:
This pull request aims to enhance the user experience by providing clearer insights into the structure of experiments and their distribution across backends. It introduces two new public methods, `_max_circuits()` and `job_info(backend)`, while also refactoring the existing `_run_jobs()` method for better code organization and reuse of logic.

### Proposed Changes:

Add` _max_circuits()` Method:
This method will calculate the maximum number of circuits that can be included in a single job. This method will encapsulate the logic previously present in the ` _run_jobs()` method to determine the maximum circuits per job.

Add `job_info(backend)` Method:
 This method will utilize the `_max_circuits()` method to provide users with information about the experiment's configuration for a specific backend. If the backend argument is provided, the method will return the number of circuits and the number of jobs the experiment will be split into on that backend. If the backend argument is not provided, the method will rely on the backend already specified in the experiment.

Refactor `_run_jobs()` Method:
The existing `_run_jobs()` method will be refactored to make use of the `_max_circuits()` method. This change will enhance code readability and maintainability by segregating the logic related to job distribution from the actual job execution logic.

### Testing 
Added `test_max_circuits` for testing of `_max_circuits()` and `test_job_info` for testing of `job_info(backend)` these tests ensure that methods functioning correctly

