### PR TITLE
Fix default cvxpy solver

### DIFF
--- a/qiskit_experiments/library/tomography/fitters/cvxpy_utils.py
+++ b/qiskit_experiments/library/tomography/fitters/cvxpy_utils.py
@@ -64,7 +64,9 @@ def requires_cvxpy(func: Callable) -> Callable:
     return decorated_func
 
 
-def solve_iteratively(problem: Problem, initial_iters: int, scale: int = 2, **solve_kwargs) -> None:
+def solve_iteratively(
+    problem: Problem, initial_iters: int, scale: int = 2, solver: str = "SCS", **solve_kwargs
+) -> None:
     """Solve a CVXPY problem increasing iterations if solution is inaccurate.
 
     If the problem is not solved with the ``initial_iters`` value of
@@ -90,7 +92,7 @@ def solve_iteratively(problem: Problem, initial_iters: int, scale: int = 2, **so
     problem_solved = False
     while not problem_solved:
         solve_kwargs["max_iters"] = current_max_iters
-        problem.solve(**solve_kwargs)
+        problem.solve(solver=solver, **solve_kwargs)
         if problem.status in ["optimal_inaccurate", "optimal"]:
             problem_solved = True
         elif problem.status == "unbounded_inaccurate":

--- a/qiskit_experiments/library/tomography/fitters/cvxpy_utils.py
+++ b/qiskit_experiments/library/tomography/fitters/cvxpy_utils.py
@@ -81,6 +81,7 @@ def solve_iteratively(
                        when solving the problem
         scale: Scale factor for increasing the initial_iters up to
                max_iters at each step (Default: 2).
+        solver: The solver to use. Defaults to the Splitting Conic Solver.
         solve_kwargs: kwargs for problem.solve method.
 
     Raises:

--- a/test/library/calibration/test_drag.py
+++ b/test/library/calibration/test_drag.py
@@ -74,6 +74,7 @@ class TestDragEndToEnd(QiskitExperimentsTestCase):
         self.assertExperimentDone(expdata)
         result = expdata.analysis_results(1)
 
+        # pylint: disable=no-member
         self.assertTrue(abs(result.value.n - backend.experiment_helper.ideal_beta) < self.test_tol)
         self.assertEqual(result.quality, "good")
         self.assertEqual(expdata.metadata["meas_level"], MeasLevel.CLASSIFIED)

--- a/test/library/calibration/test_rough_amplitude.py
+++ b/test/library/calibration/test_rough_amplitude.py
@@ -100,14 +100,15 @@ class TestRoughAmpCal(QiskitExperimentsTestCase):
 class TestSpecializations(QiskitExperimentsTestCase):
     """Test the specialized versions of the calibration."""
 
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
         """Setup the tests"""
-        super().setUp()
+        super().setUpClass()
 
         library = FixedFrequencyTransmon()
 
-        self.backend = SingleTransmonTestBackend(noise=False)
-        self.cals = Calibrations.from_backend(self.backend, libraries=[library])
+        cls.backend = SingleTransmonTestBackend(noise=False)
+        cls.cals = Calibrations.from_backend(cls.backend, libraries=[library])
 
         # Add some pulses on the 1-2 transition.
         d0 = pulse.DriveChannel(0)
@@ -119,12 +120,12 @@ class TestSpecializations(QiskitExperimentsTestCase):
             with pulse.frequency_offset(-300e6, d0):
                 pulse.play(pulse.Drag(Parameter("duration"), Parameter("amp"), 40, 0.0), d0)
 
-        self.cals.add_schedule(x12, 0)
-        self.cals.add_schedule(sx12, 0)
-        self.cals.add_parameter_value(0.4, "amp", 0, "x12")
-        self.cals.add_parameter_value(0.2, "amp", 0, "sx12")
-        self.cals.add_parameter_value(160, "duration", 0, "x12")
-        self.cals.add_parameter_value(160, "duration", 0, "sx12")
+        cls.cals.add_schedule(x12, 0)
+        cls.cals.add_schedule(sx12, 0)
+        cls.cals.add_parameter_value(0.4, "amp", 0, "x12")
+        cls.cals.add_parameter_value(0.2, "amp", 0, "sx12")
+        cls.cals.add_parameter_value(160, "duration", 0, "x12")
+        cls.cals.add_parameter_value(160, "duration", 0, "sx12")
 
     def test_ef_circuits(self):
         """Test that we get the expected circuits with calibrations for the EF experiment."""


### PR DESCRIPTION
### Summary

Similar to https://github.com/Qiskit/qiskit/pull/11002, this PR fixes the default solver for cvxpy to SCS. The 1.4.0 release changing the default solver to Clarabel breaks tomography experiments because Clarabel expects `max_iter` instead of `max_iters`. Also fixes a new lint error in `test_drag.py` and reduces `test_ef_update`'s runtime.