### PR TITLE
Figure extraction from experiment data by name without extension

### DIFF
--- a/qiskit_experiments/framework/experiment_data.py
+++ b/qiskit_experiments/framework/experiment_data.py
@@ -1311,6 +1311,12 @@ class ExperimentData:
                 raise ExperimentEntryNotFound(f"Figure {figure_key} not found.")
             figure_key = self._figures.keys()[figure_key]
 
+        # All figures must have '.svg' in their names when added, as the extension is added to the key
+        # name in the `add_figures()` method of this class.
+        if isinstance(figure_key, str):
+            if ".svg" not in figure_key:
+                figure_key += ".svg"
+
         figure_data = self._figures.get(figure_key, None)
         if figure_data is None and self.service:
             figure = self.service.figure(experiment_id=self.experiment_id, figure_name=figure_key)

--- a/qiskit_experiments/framework/experiment_data.py
+++ b/qiskit_experiments/framework/experiment_data.py
@@ -1314,7 +1314,7 @@ class ExperimentData:
         # All figures must have '.svg' in their names when added, as the extension is added to the key
         # name in the `add_figures()` method of this class.
         if isinstance(figure_key, str):
-            if ".svg" not in figure_key:
+            if not figure_key.endswith(".svg"):
                 figure_key += ".svg"
 
         figure_data = self._figures.get(figure_key, None)

--- a/releasenotes/notes/access_figure_without_extension-5b7438c19e223d6b.yaml
+++ b/releasenotes/notes/access_figure_without_extension-5b7438c19e223d6b.yaml
@@ -1,4 +1,4 @@
 ---
 upgrade:
   - |
-    Figures in `ExperimentData` objects can now be access without '.svg' extension.
+    Figures in `ExperimentData` objects can now be accessed without '.svg' extension.

--- a/releasenotes/notes/access_figure_without_extension-5b7438c19e223d6b.yaml
+++ b/releasenotes/notes/access_figure_without_extension-5b7438c19e223d6b.yaml
@@ -1,0 +1,4 @@
+---
+upgrade:
+  - |
+    Figures in `ExperimentData` objects can now be access without '.svg' extension.

--- a/test/database_service/test_db_experiment_data.py
+++ b/test/database_service/test_db_experiment_data.py
@@ -409,6 +409,8 @@ class TestDbExperimentData(QiskitExperimentsTestCase):
         exp_data = ExperimentData(experiment_type="qiskit_test")
         figure_template = "hello world {}"
         name_template = "figure_{}.svg"
+        name_template_wo_ext = "figure_{}"
+
         for idx in range(3):
             exp_data.add_figures(
                 str.encode(figure_template.format(idx)), figure_names=name_template.format(idx)
@@ -416,6 +418,11 @@ class TestDbExperimentData(QiskitExperimentsTestCase):
         idx = randrange(3)
         expected_figure = str.encode(figure_template.format(idx))
         self.assertEqual(expected_figure, exp_data.figure(name_template.format(idx)).figure)
+        self.assertEqual(expected_figure, exp_data.figure(idx).figure)
+
+        # Check that figure will be returned without file extension in name
+        expected_figure = str.encode(figure_template.format(idx))
+        self.assertEqual(expected_figure, exp_data.figure(name_template_wo_ext.format(idx)).figure)
         self.assertEqual(expected_figure, exp_data.figure(idx).figure)
 
         file_name = uuid.uuid4().hex


### PR DESCRIPTION
### Summary

Figure names could be referred without ".svg" at the ending.
### Details and comments

Some details that should be in this section include:
In #629 , an issue was raised where a figure that was saved with the name "abcd" couldn't be accessed. This issue is caused by that the 'add_figures()' method in `ExperimentData` class added ".svg" automatically. As it explicitly written that SVG extension is added if the file name doesn't have one, we can conclude that all figure names have ".svg" extension.  To not make a major change in the code I added to the `figure` method in `ExperimentData` class a check for the extension of the `figure_key`. If it doesn't have ".svg" ending, it adds one before trying to pull it from the dict of figures.

