### PR TITLE
Pluggable Clifford synthesis for RB circuits

### DIFF
--- a/qiskit_experiments/library/randomized_benchmarking/clifford_synthesis.py
+++ b/qiskit_experiments/library/randomized_benchmarking/clifford_synthesis.py
@@ -1,0 +1,58 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2023.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+"""
+Clifford synthesis plugins for randomized benchmarking
+"""
+from __future__ import annotations
+
+from qiskit.circuit import QuantumCircuit, Operation
+from qiskit.synthesis.clifford import synth_clifford_full
+from qiskit.transpiler import PassManager, CouplingMap, Layout
+from qiskit.transpiler.passes import SabreSwap, LayoutTransformation
+from qiskit.transpiler.passes.synthesis.plugin import HighLevelSynthesisPlugin
+
+
+class RBDefaultCliffordSynthesis(HighLevelSynthesisPlugin):
+    """Default Clifford synthesis plugin for randomized benchmarking."""
+
+    def run(
+        self,
+        high_level_object: Operation,
+        coupling_map: CouplingMap | None = None,
+        **options,
+    ) -> QuantumCircuit:
+        """Run synthesis for the given Clifford.
+
+        Args:
+            high_level_object: The Operation to synthesize to a
+                :class:`~qiskit.dagcircuit.DAGCircuit` object.
+            coupling_map: The reduced coupling map of the backend. For example,
+                if physical qubits [5, 6, 7] to be benchmarked is connected
+                as 5 - 7 - 6 linearly, the reduced coupling map is 0 - 2 - 1.
+            options: Additional method-specific optional kwargs.
+
+        Returns:
+            The quantum circuit representation of the Operation
+                when successful, and ``None`` otherwise.
+        """
+        # synthesize cliffords
+        circ = synth_clifford_full(high_level_object)
+        if coupling_map is None:  # Sabre does not work with coupling_map=None
+            return circ
+        # run Sabre routing and undo the layout change
+        # assuming Sabre routing does not change the initial layout
+        initial_layout = Layout.generate_trivial_layout(*circ.qubits)
+        undo_layout_change = LayoutTransformation(
+            coupling_map=coupling_map, from_layout="final_layout", to_layout=initial_layout
+        )
+        pm = PassManager([SabreSwap(coupling_map), undo_layout_change])
+        return pm.run(circ)

--- a/qiskit_experiments/library/randomized_benchmarking/clifford_synthesis.py
+++ b/qiskit_experiments/library/randomized_benchmarking/clifford_synthesis.py
@@ -20,7 +20,7 @@ from qiskit.circuit import QuantumCircuit, Operation
 from qiskit.circuit.equivalence_library import SessionEquivalenceLibrary as sel
 from qiskit.exceptions import QiskitError
 from qiskit.synthesis.clifford import synth_clifford_full
-from qiskit.transpiler import PassManager, CouplingMap, Layout
+from qiskit.transpiler import PassManager, CouplingMap, Layout, Target
 from qiskit.transpiler.passes import (
     SabreSwap,
     LayoutTransformation,
@@ -38,8 +38,9 @@ class RBDefaultCliffordSynthesis(HighLevelSynthesisPlugin):
     def run(
         self,
         high_level_object: Operation,
-        basis_gates: Sequence[str] | None = None,
         coupling_map: CouplingMap | None = None,
+        target: Target | None = None,
+        qubits: Sequence | None = None,
         **options,
     ) -> QuantumCircuit:
         """Run synthesis for the given Clifford.
@@ -47,11 +48,14 @@ class RBDefaultCliffordSynthesis(HighLevelSynthesisPlugin):
         Args:
             high_level_object: The operation to synthesize to a
                 :class:`~qiskit.circuit.QuantumCircuit` object.
-            basis_gates: The basis gates to be used for the synthesis.
             coupling_map: The reduced coupling map of the backend. For example,
                 if physical qubits [5, 6, 7] to be benchmarked is connected
                 as 5 - 7 - 6 linearly, the reduced coupling map is 0 - 2 - 1.
-            options: Additional method-specific optional kwargs.
+            target: A target representing the target backend, which will be ignored in this plugin.
+            qubits: List of physical qubits over which the operation is defined,
+                which will be ignored in this plugin.
+            options: Additional method-specific optional kwargs,
+                which must include ``basis_gates``, basis gates to be used for the synthesis.
 
         Returns:
             The quantum circuit representation of the Operation
@@ -67,6 +71,7 @@ class RBDefaultCliffordSynthesis(HighLevelSynthesisPlugin):
         if coupling_map is None:  # Sabre does not work with coupling_map=None
             return circ
 
+        basis_gates = options.get("basis_gates", None)
         if basis_gates is None:
             raise QiskitError("basis_gates are required to run this synthesis plugin")
 

--- a/qiskit_experiments/library/randomized_benchmarking/clifford_utils.py
+++ b/qiskit_experiments/library/randomized_benchmarking/clifford_utils.py
@@ -224,6 +224,44 @@ def _clifford_2q_int_to_instruction(
     ).to_instruction()
 
 
+def _hash_cliff(cliff):
+    return cliff.tableau.tobytes(), cliff.tableau.shape
+
+
+def _dehash_cliff(cliff_hash):
+    tableau = np.frombuffer(cliff_hash[0], dtype=bool).reshape(cliff_hash[1])
+    return Clifford(tableau)
+
+
+def _clifford_to_instruction(
+    clifford: Clifford,
+    basis_gates: Optional[Tuple[str]],
+    coupling_tuple: Optional[Tuple[Tuple[int, int]]],
+    synthesis_method: str = DEFAULT_SYNTHESIS_METHOD,
+) -> Instruction:
+    return _cached_clifford_to_instruction(
+        _hash_cliff(clifford),
+        basis_gates=basis_gates,
+        coupling_tuple=coupling_tuple,
+        synthesis_method=synthesis_method,
+    )
+
+
+@lru_cache(maxsize=256)
+def _cached_clifford_to_instruction(
+    cliff_hash: Tuple[str, Tuple[int, int]],
+    basis_gates: Optional[Tuple[str]],
+    coupling_tuple: Optional[Tuple[Tuple[int, int]]],
+    synthesis_method: str = DEFAULT_SYNTHESIS_METHOD,
+) -> Instruction:
+    return _synthesize_clifford(
+        _dehash_cliff(cliff_hash),
+        basis_gates=basis_gates,
+        coupling_tuple=coupling_tuple,
+        synthesis_method=synthesis_method,
+    ).to_instruction()
+
+
 # The classes VGate and WGate are not actually used in the code - we leave them here to give
 # a better understanding of the composition of the layers for 2-qubit Cliffords.
 class VGate(Gate):

--- a/qiskit_experiments/library/randomized_benchmarking/clifford_utils.py
+++ b/qiskit_experiments/library/randomized_benchmarking/clifford_utils.py
@@ -114,17 +114,6 @@ def _circuit_compose(
     return self
 
 
-def _truncate_inactive_qubits(
-    circ: QuantumCircuit, active_qubits: Sequence[Qubit]
-) -> QuantumCircuit:
-    res = QuantumCircuit(active_qubits, name=circ.name, metadata=circ.metadata)
-    for inst in circ:
-        if all(q in active_qubits for q in inst.qubits):
-            res.append(inst)
-    res.calibrations = circ.calibrations
-    return res
-
-
 def _synthesize_clifford(
     clifford: Clifford,
     basis_gates: Optional[Tuple[str]],

--- a/qiskit_experiments/library/randomized_benchmarking/interleaved_rb_experiment.py
+++ b/qiskit_experiments/library/randomized_benchmarking/interleaved_rb_experiment.py
@@ -14,7 +14,7 @@ Interleaved RB Experiment class.
 """
 import itertools
 import warnings
-from typing import Union, Iterable, Optional, List, Sequence, Tuple
+from typing import Union, Iterable, Optional, List, Sequence, Dict, Any
 
 from numpy.random import Generator
 from numpy.random.bit_generator import BitGenerator, SeedSequence
@@ -225,17 +225,19 @@ class InterleavedRB(StandardRB):
         return list(itertools.chain.from_iterable(zip(reference_circuits, interleaved_circuits)))
 
     def _to_instruction(
-        self, elem: SequenceElementType, basis_gates: Optional[Tuple[str]] = None
+        self,
+        elem: SequenceElementType,
+        synthesis_options: Dict[str, Optional[Any]],
     ) -> Instruction:
         if elem is self._interleaved_cliff:
             return self._interleaved_op
 
-        return super()._to_instruction(elem, basis_gates)
+        return super()._to_instruction(elem, synthesis_options)
 
     def __set_up_interleaved_op(self) -> None:
         # Convert interleaved element to transpiled circuit operation and store it for speed
         self._interleaved_op = self._interleaved_element
-        basis_gates = self._get_basis_gates()
+        basis_gates = self._get_synthesis_options()["basis_gates"]
         # Convert interleaved element to circuit
         if isinstance(self._interleaved_op, Clifford):
             self._interleaved_op = self._interleaved_op.to_circuit()

--- a/qiskit_experiments/library/randomized_benchmarking/standard_rb.py
+++ b/qiskit_experiments/library/randomized_benchmarking/standard_rb.py
@@ -41,8 +41,8 @@ from .clifford_utils import (
     inverse_2q,
     _clifford_1q_int_to_instruction,
     _clifford_2q_int_to_instruction,
+    _clifford_to_instruction,
     _transpile_clifford_circuit,
-    _synthesize_clifford,
 )
 from .rb_analysis import RBAnalysis
 
@@ -332,8 +332,7 @@ class StandardRB(BaseExperiment, RestlessMixin):
             if self.num_qubits == 2:
                 return _clifford_2q_int_to_instruction(elem, **synthesis_options)
 
-        cliff_circ = _synthesize_clifford(elem, **synthesis_options)
-        return cliff_circ.to_instruction()
+        return _clifford_to_instruction(elem, **synthesis_options)
 
     def __identity_clifford(self) -> SequenceElementType:
         if self.num_qubits <= 2:
@@ -347,11 +346,11 @@ class StandardRB(BaseExperiment, RestlessMixin):
             return functools.reduce(
                 compose_1q if self.num_qubits == 1 else compose_2q, elements, base_elem
             )
-        # 3 or more qubits: compose Clifford from circuits for speed
-        circ = QuantumCircuit(self.num_qubits)
+        # 3 or more qubits
+        res = base_elem
         for elem in elements:
-            circ.compose(elem, inplace=True)
-        return base_elem.compose(Clifford.from_circuit(circ))
+            res = res.compose(elem)
+        return res
 
     def __adjoint_clifford(self, op: SequenceElementType) -> SequenceElementType:
         if self.num_qubits == 1:

--- a/qiskit_experiments/library/randomized_benchmarking/standard_rb.py
+++ b/qiskit_experiments/library/randomized_benchmarking/standard_rb.py
@@ -23,7 +23,7 @@ import rustworkx as rx
 from numpy.random import Generator, default_rng
 from numpy.random.bit_generator import BitGenerator, SeedSequence
 
-from qiskit.circuit import CircuitInstruction, QuantumCircuit, Instruction, Barrier
+from qiskit.circuit import CircuitInstruction, QuantumCircuit, Instruction, Barrier, Gate
 from qiskit.exceptions import QiskitError
 from qiskit.providers import BackendV2Converter
 from qiskit.providers.backend import Backend, BackendV1, BackendV2
@@ -236,11 +236,10 @@ class StandardRB(BaseExperiment, RestlessMixin):
                 basis_gates = basis_gates if basis_gates else self.backend.target.operation_names
                 coupling_map = coupling_map if coupling_map else None
             elif isinstance(self.backend, BackendV2):
-                backend_basis_gates = [
-                    op.name for op in self.backend.target.operations if op.num_qubits != 2
-                ]
+                gate_ops = [op for op in self.backend.target.operations if isinstance(op, Gate)]
+                backend_basis_gates = [op.name for op in gate_ops if op.num_qubits != 2]
                 backend_cmap = None
-                for op in self.backend.target.operations:
+                for op in gate_ops:
                     if op.num_qubits != 2:
                         continue
                     cmap = self.backend.target.build_coupling_map(op.name)

--- a/qiskit_experiments/library/randomized_benchmarking/standard_rb.py
+++ b/qiskit_experiments/library/randomized_benchmarking/standard_rb.py
@@ -30,6 +30,7 @@ from qiskit.providers.backend import Backend, BackendV1, BackendV2
 from qiskit.pulse.instruction_schedule_map import CalibrationPublisher
 from qiskit.quantum_info import Clifford
 from qiskit.quantum_info.random import random_clifford
+from qiskit.transpiler import CouplingMap
 from qiskit_experiments.framework import BaseExperiment, Options
 from qiskit_experiments.framework.restless_mixin import RestlessMixin
 from .clifford_utils import (
@@ -251,7 +252,7 @@ class StandardRB(BaseExperiment, RestlessMixin):
                 backend_basis_gates = self.backend.configuration().basis_gates
                 backend_cmap = self.backend.configuration().coupling_map
                 if backend_cmap:
-                    backend_cmap = backend_cmap.reduce(self.physical_qubits)
+                    backend_cmap = CouplingMap(backend_cmap).reduce(self.physical_qubits)
                 basis_gates = basis_gates if basis_gates else backend_basis_gates
                 coupling_map = coupling_map if coupling_map else backend_cmap
 

--- a/qiskit_experiments/library/randomized_benchmarking/standard_rb.py
+++ b/qiskit_experiments/library/randomized_benchmarking/standard_rb.py
@@ -379,10 +379,8 @@ class StandardRB(BaseExperiment, RestlessMixin):
             ]
             # Set custom calibrations provided in backend
             if isinstance(self.backend, BackendV2):
-                qargs_patterns = []
-                if self.num_qubits == 1:
-                    qargs_patterns = [self.physical_qubits]
-                elif self.num_qubits == 2:
+                qargs_patterns = [self.physical_qubits]  # for 1q or 3q+ case
+                if self.num_qubits == 2:
                     qargs_patterns = [
                         (self.physical_qubits[0],),
                         (self.physical_qubits[1],),

--- a/qiskit_experiments/library/randomized_benchmarking/standard_rb.py
+++ b/qiskit_experiments/library/randomized_benchmarking/standard_rb.py
@@ -12,13 +12,14 @@
 """
 Standard RB Experiment class.
 """
-import logging
 import functools
+import logging
 from collections import defaultdict
 from numbers import Integral
-from typing import Union, Iterable, Optional, List, Sequence, Tuple
+from typing import Union, Iterable, Optional, List, Sequence, Dict, Any
 
 import numpy as np
+import rustworkx as rx
 from numpy.random import Generator, default_rng
 from numpy.random.bit_generator import BitGenerator, SeedSequence
 
@@ -29,11 +30,8 @@ from qiskit.providers.backend import Backend, BackendV1, BackendV2
 from qiskit.pulse.instruction_schedule_map import CalibrationPublisher
 from qiskit.quantum_info import Clifford
 from qiskit.quantum_info.random import random_clifford
-from qiskit.transpiler import CouplingMap
-
 from qiskit_experiments.framework import BaseExperiment, Options
 from qiskit_experiments.framework.restless_mixin import RestlessMixin
-
 from .clifford_utils import (
     CliffordUtils,
     compose_1q,
@@ -43,6 +41,7 @@ from .clifford_utils import (
     _clifford_1q_int_to_instruction,
     _clifford_2q_int_to_instruction,
     _transpile_clifford_circuit,
+    _synthesize_clifford,
 )
 from .rb_analysis import RBAnalysis
 
@@ -147,6 +146,8 @@ class StandardRB(BaseExperiment, RestlessMixin):
             full_sampling (bool): If True all Cliffords are independently sampled for
                 all lengths. If False for sample of lengths longer sequences are constructed
                 by appending additional Clifford samples to shorter sequences.
+            clifford_synthesis_method (str): The name of the Clifford synthesis plugin to use
+                for building circuits of RB sequences.
         """
         options = super()._default_experiment_options()
         options.update_options(
@@ -154,6 +155,7 @@ class StandardRB(BaseExperiment, RestlessMixin):
             num_samples=None,
             seed=None,
             full_sampling=None,
+            clifford_synthesis_method="rb_default",
         )
 
         return options
@@ -211,64 +213,52 @@ class StandardRB(BaseExperiment, RestlessMixin):
 
         return sequences
 
-    def _get_basis_gates(self) -> Optional[Tuple[str, ...]]:
-        """Get sorted basis gates to use in basis transformation during circuit generation.
+    def _get_synthesis_options(self) -> Dict[str, Optional[Any]]:
+        """Get options for Clifford synthesis from the backend information as a dictionary.
 
-        - Return None if this experiment is an RB with 3 or more qubits.
-        - Return None if no basis gates are supplied via ``backend`` or ``transpile_options``.
-        - Return None if all 2q-gates supported on the physical qubits of the backend are one-way
-        directed (e.g. cx(0, 1) is supported but cx(1, 0) is not supported).
-
-        In all those case when None are returned, basis transformation will be skipped in the
-        circuit generation step (i.e. :meth:`circuits`) and it will be done in the successive
-        transpilation step (i.e. :meth:`_transpiled_circuits`) that calls :func:`transpile`.
+        The options includes:
+        - "basis_gates": Sorted basis gate names.
+            Return None if no basis gates are supplied via ``backend`` or ``transpile_options``.
+        - "coupling_tuple": Reduced coupling map in the form of tuple of edges in the coupling graph.
+            Return None if no coupling map are supplied via ``backend`` or ``transpile_options``.
 
         Returns:
             Sorted basis gate names.
         """
-        # 3 or more qubits case: Return None (skip basis transformation in circuit generation)
-        if self.num_qubits > 2:
-            return None
+        basis_gates = self.transpile_options.get("basis_gates", [])
+        coupling_map = self.transpile_options.get("coupling_map", None)
+        if coupling_map:
+            coupling_map = coupling_map.reduce(self.physical_qubits)
+        if not (basis_gates and coupling_map) and self.backend:
+            if isinstance(self.backend, BackendV2) and self.backend.target:
+                backend_basis_gates = []
+                backend_cmap = None
+                for op in self.backend.target.operations:
+                    if op.num_qubits == 2:
+                        cmap = self.backend.target.build_coupling_map(op.name)
+                        if cmap:
+                            reduced = cmap.reduce(self.physical_qubits)
+                            if rx.is_weakly_connected(reduced.graph):
+                                backend_basis_gates.append(op.name)
+                                backend_cmap = reduced
+                                break
+                    else:
+                        backend_basis_gates.append(op.name)
+                basis_gates = basis_gates if basis_gates else backend_basis_gates
+                coupling_map = coupling_map if coupling_map else backend_cmap
+            elif isinstance(self.backend, BackendV1):
+                backend_basis_gates = self.backend.configuration().basis_gates
+                backend_cmap = self.backend.configuration().coupling_map
+                if backend_cmap:
+                    backend_cmap = backend_cmap.reduce(self.physical_qubits)
+                basis_gates = basis_gates if basis_gates else backend_basis_gates
+                coupling_map = coupling_map if coupling_map else backend_cmap
 
-        # 1 qubit case: Return all basis gates (or None if no basis gates are supplied)
-        if self.num_qubits == 1:
-            basis_gates = self.transpile_options.get("basis_gates", None)
-            if not basis_gates and self.backend:
-                if isinstance(self.backend, BackendV2):
-                    basis_gates = self.backend.operation_names
-                elif isinstance(self.backend, BackendV1):
-                    basis_gates = self.backend.configuration().basis_gates
-            return tuple(sorted(basis_gates)) if basis_gates else None
-
-        def is_bidirectional(coupling_map):
-            if coupling_map is None:
-                # None for a coupling map implies all-to-all coupling
-                return True
-            return len(coupling_map.reduce(self.physical_qubits).get_edges()) == 2
-
-        # 2 qubits case: Return all basis gates except for one-way directed 2q-gates.
-        # Return None if there is no bidirectional 2q-gates in basis gates.
-        if self.num_qubits == 2:
-            basis_gates = self.transpile_options.get("basis_gates", [])
-            if not basis_gates and self.backend:
-                if isinstance(self.backend, BackendV2) and self.backend.target:
-                    has_bidirectional_2q_gates = False
-                    for op_name in self.backend.target:
-                        if self.backend.target.operation_from_name(op_name).num_qubits == 2:
-                            if is_bidirectional(self.backend.target.build_coupling_map(op_name)):
-                                has_bidirectional_2q_gates = True
-                            else:
-                                continue
-                        basis_gates.append(op_name)
-                    if not has_bidirectional_2q_gates:
-                        basis_gates = None
-                elif isinstance(self.backend, BackendV1):
-                    cmap = self.backend.configuration().coupling_map
-                    if cmap is None or is_bidirectional(CouplingMap(cmap)):
-                        basis_gates = self.backend.configuration().basis_gates
-            return tuple(sorted(basis_gates)) if basis_gates else None
-
-        return None
+        return {
+            "basis_gates": tuple(sorted(basis_gates)) if basis_gates else None,
+            "coupling_tuple": tuple(sorted(coupling_map.get_edges())) if coupling_map else None,
+            "method": self.experiment_options["clifford_synthesis_method"],
+        }
 
     def _sequences_to_circuits(
         self, sequences: List[Sequence[SequenceElementType]]
@@ -278,7 +268,7 @@ class StandardRB(BaseExperiment, RestlessMixin):
         Returns:
             A list of RB circuits.
         """
-        basis_gates = self._get_basis_gates()
+        synthesis_opts = self._get_synthesis_options()
         # Circuit generation
         circuits = []
         for i, seq in enumerate(sequences):
@@ -290,7 +280,7 @@ class StandardRB(BaseExperiment, RestlessMixin):
 
             circ = QuantumCircuit(self.num_qubits)
             for elem in seq:
-                circ.append(self._to_instruction(elem, basis_gates), circ.qubits)
+                circ.append(self._to_instruction(elem, synthesis_opts), circ.qubits)
                 circ._append(CircuitInstruction(Barrier(self.num_qubits), circ.qubits))
 
             # Compute inverse, compute only the difference from the previous shorter sequence
@@ -298,7 +288,7 @@ class StandardRB(BaseExperiment, RestlessMixin):
             prev_seq = seq
             inv = self.__adjoint_clifford(prev_elem)
 
-            circ.append(self._to_instruction(inv, basis_gates), circ.qubits)
+            circ.append(self._to_instruction(inv, synthesis_opts), circ.qubits)
             circ.measure_all()  # includes insertion of the barrier before measurement
             circuits.append(circ)
         return circuits
@@ -310,20 +300,41 @@ class StandardRB(BaseExperiment, RestlessMixin):
             return rng.integers(CliffordUtils.NUM_CLIFFORD_1_QUBIT, size=length)
         if self.num_qubits == 2:
             return rng.integers(CliffordUtils.NUM_CLIFFORD_2_QUBIT, size=length)
-        # Return circuit object instead of Clifford object for 3 or more qubits case for speed
-        return [random_clifford(self.num_qubits, rng).to_circuit() for _ in range(length)]
+        # Return Clifford object for 3 or more qubits case
+        return [random_clifford(self.num_qubits, rng) for _ in range(length)]
 
     def _to_instruction(
-        self, elem: SequenceElementType, basis_gates: Optional[Tuple[str, ...]] = None
+        self,
+        elem: SequenceElementType,
+        synthesis_options: Dict[str, Optional[Any]],
     ) -> Instruction:
+        """Return the instruction of a Clifford element.
+
+        The resulting instruction contains a circuit definition with ``basis_gates`` and
+        it complies with ``coupling_tuple``, which is specified in ``synthesis_options``.
+
+        Args:
+            elem: a Clifford element to be converted
+            synthesis_options: options for synthesizing the Clifford element
+
+        Returns:
+            Converted instruction
+        """
         # Switching for speed up
         if isinstance(elem, Integral):
             if self.num_qubits == 1:
-                return _clifford_1q_int_to_instruction(elem, basis_gates)
+                return _clifford_1q_int_to_instruction(
+                    elem, basis_gates=synthesis_options["basis_gates"]
+                )
             if self.num_qubits == 2:
-                return _clifford_2q_int_to_instruction(elem, basis_gates)
+                return _clifford_2q_int_to_instruction(
+                    elem,
+                    basis_gates=synthesis_options["basis_gates"],
+                    coupling_tuple=synthesis_options["coupling_tuple"],
+                )
 
-        return elem.to_instruction()
+        cliff_circ = _synthesize_clifford(elem, **synthesis_options)
+        return cliff_circ.to_instruction()
 
     def __identity_clifford(self) -> SequenceElementType:
         if self.num_qubits <= 2:
@@ -355,11 +366,12 @@ class StandardRB(BaseExperiment, RestlessMixin):
     def _transpiled_circuits(self) -> List[QuantumCircuit]:
         """Return a list of experiment circuits, transpiled."""
         has_custom_transpile_option = (
-            not set(vars(self.transpile_options)).issubset({"basis_gates", "optimization_level"})
+            not set(vars(self.transpile_options)).issubset(
+                {"basis_gates", "coupling_map", "optimization_level"}
+            )
             or self.transpile_options.get("optimization_level", 1) != 1
         )
-        has_no_undirected_2q_basis = self._get_basis_gates() is None
-        if self.num_qubits > 2 or has_custom_transpile_option or has_no_undirected_2q_basis:
+        if has_custom_transpile_option:
             transpiled = super()._transpiled_circuits()
         else:
             transpiled = [
@@ -368,8 +380,10 @@ class StandardRB(BaseExperiment, RestlessMixin):
             ]
             # Set custom calibrations provided in backend
             if isinstance(self.backend, BackendV2):
-                qargs_patterns = [self.physical_qubits]  # for self.num_qubits == 1
-                if self.num_qubits == 2:
+                qargs_patterns = []
+                if self.num_qubits == 1:
+                    qargs_patterns = [self.physical_qubits]
+                elif self.num_qubits == 2:
                     qargs_patterns = [
                         (self.physical_qubits[0],),
                         (self.physical_qubits[1],),
@@ -377,10 +391,12 @@ class StandardRB(BaseExperiment, RestlessMixin):
                         (self.physical_qubits[1], self.physical_qubits[0]),
                     ]
 
+                qargs_supported = self.backend.target.qargs
                 instructions = []  # (op_name, qargs) for each element where qargs means qubit tuple
                 for qargs in qargs_patterns:
-                    for op_name in self.backend.target.operation_names_for_qargs(qargs):
-                        instructions.append((op_name, qargs))
+                    if qargs in qargs_supported:
+                        for op_name in self.backend.target.operation_names_for_qargs(qargs):
+                            instructions.append((op_name, qargs))
 
                 common_calibrations = defaultdict(dict)
                 for op_name, qargs in instructions:

--- a/releasenotes/notes/plugable-rb-clifford-synthesis-0e66c62fa3088fba.yaml
+++ b/releasenotes/notes/plugable-rb-clifford-synthesis-0e66c62fa3088fba.yaml
@@ -1,0 +1,20 @@
+---
+features:
+  - |
+    Added a new experiment option ``clifford_synthesis_method`` to RB experiemnts,
+    e.g. :class:`~.StandardRB`, :class:`~.InterleavedRB` so that users can
+    plug in a custom Clifford synsthesis algorithm used for generating RB circuits.
+    Such a plugin should be implemented as a ``HighLevelSynthesisPlugin``
+    (see :class:`~.RBDefaultCliffordSynthesis` for example).
+upgrade:
+  - |
+    Updated :class:`~.InterleavedRB` so that it only accepts ``interleaved_element``
+    consisting only of instructions supported by the backend of interest.
+fixes:
+  - |
+    Fixed a bug in circuit generation for three or more qubit RB where
+    sampled Cliffords may be changed during their circuits synthesis
+    (in the worst case, the resulting circuits may use qubits not in
+    ``physical_qubits``). See issue
+    `#1279 <https://github.com/Qiskit-Extensions/qiskit-experiments/issues/1279>`_
+    for additional details.

--- a/releasenotes/notes/plugable-rb-clifford-synthesis-0e66c62fa3088fba.yaml
+++ b/releasenotes/notes/plugable-rb-clifford-synthesis-0e66c62fa3088fba.yaml
@@ -1,9 +1,9 @@
 ---
 features:
   - |
-    Added a new experiment option ``clifford_synthesis_method`` to RB experiemnts,
-    e.g. :class:`~.StandardRB`, :class:`~.InterleavedRB` so that users can
-    plug in a custom Clifford synsthesis algorithm used for generating RB circuits.
+    Added a new experiment option ``clifford_synthesis_method`` to RB experiments,
+    e.g. :class:`~.StandardRB` and :class:`~.InterleavedRB` so that users can
+    plug in a custom Clifford synthesis algorithm used for generating RB circuits.
     Such a plugin should be implemented as a ``HighLevelSynthesisPlugin``
     (see :class:`~.RBDefaultCliffordSynthesis` for example).
 upgrade:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,3 @@
-qiskit>=0.45.0
 black~=22.0
 fixtures
 stestr

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy>=1.17
 scipy>=1.4
-qiskit>=0.44
+qiskit>=0.45
 qiskit-ibm-experiment>=0.3.4
 matplotlib>=3.4
 uncertainties

--- a/setup.py
+++ b/setup.py
@@ -69,4 +69,9 @@ setup(
         "Source Code": "https://github.com/Qiskit-Extensions/qiskit-experiments",
     },
     zip_safe=False,
+    entry_points={
+        "qiskit.synthesis": [
+            "clifford.rb_default = qiskit_experiments.library.randomized_benchmarking.clifford_synthesis:RBDefaultCliffordSynthesis",
+        ],
+    },
 )

--- a/test/library/randomized_benchmarking/test_clifford_utils.py
+++ b/test/library/randomized_benchmarking/test_clifford_utils.py
@@ -241,15 +241,15 @@ class TestCliffordUtils(QiskitExperimentsTestCase):
         """Check if clifford synthesis with non-linear connectivity does not change Clifford"""
         basis_gates = tuple(["rz", "sx", "cx"])
         # star
-        coupling_tuple = ((tuple((0, i) for i in range(1, num_qubits))))
+        coupling_tuple = tuple((0, i) for i in range(1, num_qubits))
         for seed in range(5):
             expected = random_clifford(num_qubits=num_qubits, seed=seed)
             circuit = _synthesize_clifford(expected, basis_gates, coupling_tuple)
             synthesized = Clifford(circuit)
             self.assertEqual(expected, synthesized)
-        
+
         # cycle
-        coupling_tuple = (tuple((i, (i + 1) % num_qubits) for i in range(num_qubits)))
+        coupling_tuple = tuple((i, (i + 1) % num_qubits) for i in range(num_qubits))
         for seed in range(5):
             expected = random_clifford(num_qubits=num_qubits, seed=seed)
             circuit = _synthesize_clifford(expected, basis_gates, coupling_tuple)

--- a/test/library/randomized_benchmarking/test_clifford_utils.py
+++ b/test/library/randomized_benchmarking/test_clifford_utils.py
@@ -224,13 +224,33 @@ class TestCliffordUtils(QiskitExperimentsTestCase):
             self.assertEqual(c, 0)
 
     @data(1, 2, 3, 4)
-    def test_clifford_synthesis(self, num_qubits):
-        """Check if clifford synthesis does not change Clifford"""
+    def test_clifford_synthesis_linear_connectivity(self, num_qubits):
+        """Check if clifford synthesis with linear connectivity does not change Clifford"""
         basis_gates = tuple(["rz", "h", "cz"])
         coupling_tuple = (
             None if num_qubits == 1 else tuple((i, i + 1) for i in range(num_qubits - 1))
         )
         for seed in range(10):
+            expected = random_clifford(num_qubits=num_qubits, seed=seed)
+            circuit = _synthesize_clifford(expected, basis_gates, coupling_tuple)
+            synthesized = Clifford(circuit)
+            self.assertEqual(expected, synthesized)
+
+    @data(3, 4, 6)
+    def test_clifford_synthesis_non_linear_connectivity(self, num_qubits):
+        """Check if clifford synthesis with non-linear connectivity does not change Clifford"""
+        basis_gates = tuple(["rz", "sx", "cx"])
+        # star
+        coupling_tuple = ((tuple((0, i) for i in range(1, num_qubits))))
+        for seed in range(5):
+            expected = random_clifford(num_qubits=num_qubits, seed=seed)
+            circuit = _synthesize_clifford(expected, basis_gates, coupling_tuple)
+            synthesized = Clifford(circuit)
+            self.assertEqual(expected, synthesized)
+        
+        # cycle
+        coupling_tuple = (tuple((i, (i + 1) % num_qubits) for i in range(num_qubits)))
+        for seed in range(5):
             expected = random_clifford(num_qubits=num_qubits, seed=seed)
             circuit = _synthesize_clifford(expected, basis_gates, coupling_tuple)
             synthesized = Clifford(circuit)

--- a/test/library/randomized_benchmarking/test_standard_rb.py
+++ b/test/library/randomized_benchmarking/test_standard_rb.py
@@ -294,7 +294,7 @@ class TestRunStandardRB(QiskitExperimentsTestCase, RBTestMixin):
         self.assertAlmostEqual(epc.value.n, epc_expected, delta=0.3 * epc_expected)
 
     def test_three_qubit(self):
-        """Test two qubit RB. Use default basis gates."""
+        """Test three qubit RB. Use default basis gates."""
         exp = rb.StandardRB(
             physical_qubits=(0, 1, 2),
             lengths=list(range(1, 30, 3)),


### PR DESCRIPTION
### Summary
Make the Clifford synthesis algorithm for RB circuits pluggable (implementing it as a `HighLevelSynthesisPlugin`).
Fixes #1279 and #1023.
Change to accept Clifford elements consisting only of instructions supported by the backend for `interleaved_element` option in `InterleavedRB`.
Speed up 2Q RB/IRB for backends with unidirectional 2q gates, e.g. IBM's 127Q Eagle processors.

### Details and comments
Previously, for 3Q+ RB circuits, entire circuit is transpiled at once and hence for each of the resulting Cliffords, the initial and the final layout may differ, that means sampled Cliffords are changed during the transpilation. Also in the worst case, the resulting circuit may use physical qubits not in the supplied `physical_qubits`. To avoid that, this commit changes to transpile an RB sequence Clifford by Clifford. The Clifford synthesis algorithm (`rb_default`) is implemented as a `HighLevelSynthesisPlugin` (see `RBDefaultCliffordSynthesis` in `clifford_synthesis.py`), which forces the initial layout (i.e. guarantees the initial layout = the final layout) and physical qubits to use. As a byproduct, the performance of 2Q RB/IRB for backends with directed 2q gates (e.g. IBM's 127Q Eagle processors) is drastically improved. For those cases, previously we had to rely on `transpile` function to make generated circuits comply with the coupling map, however, after this commit, we can synthesize Cliffords with considering the 2q-gate direction and go through the fast path introduced in #982.

Depends on https://github.com/Qiskit/qiskit/pull/10477 (qiskit 0.45)