### PR TITLE
Cap qiskit-aer version in extra dependency

### DIFF
--- a/requirements-extras.txt
+++ b/requirements-extras.txt
@@ -1,5 +1,5 @@
 qiskit-ibm-provider>=0.6.1 # for submitting experiments to backends through the IBM provider
 cvxpy>=1.3.2 # for tomography
 scikit-learn # for discriminators
-qiskit-aer>=0.11.0 # for QV simulations
+qiskit-aer<=0.12.2 # temp fix.
 qiskit_dynamics>=0.4.0 # for the PulseBackend

--- a/requirements-extras.txt
+++ b/requirements-extras.txt
@@ -1,5 +1,5 @@
 qiskit-ibm-provider>=0.6.1 # for submitting experiments to backends through the IBM provider
 cvxpy>=1.3.2 # for tomography
 scikit-learn # for discriminators
-qiskit-aer<=0.12.2 # temp fix.
+qiskit-aer>=0.11.0,<=0.12.2 # Temporary version pin because of https://github.com/Qiskit-Extensions/qiskit-experiments/issues/1292
 qiskit_dynamics>=0.4.0 # for the PulseBackend


### PR DESCRIPTION
### Summary

I found currently all PRs including the main branch fail in CI due to QPT/QST unittest including reset instruction. Likely this is due to qiskit-aer 0.13. I added version cap not to install this version as a temporary fix.