### PR TITLE
Allow StandardRB to handle a V2 backend without a coupling map

### DIFF
--- a/qiskit_experiments/library/randomized_benchmarking/standard_rb.py
+++ b/qiskit_experiments/library/randomized_benchmarking/standard_rb.py
@@ -241,6 +241,9 @@ class StandardRB(BaseExperiment, RestlessMixin):
             return tuple(sorted(basis_gates)) if basis_gates else None
 
         def is_bidirectional(coupling_map):
+            if coupling_map is None:
+                # None for a coupling map implies all-to-all coupling
+                return True
             return len(coupling_map.reduce(self.physical_qubits).get_edges()) == 2
 
         # 2 qubits case: Return all basis gates except for one-way directed 2q-gates.


### PR DESCRIPTION
`StandardRB` handles directed two-qubit gates differently from bi-directional ones. For `BackendV2`, it used the `coupling_map` to check for directionality but did not handle the case where the coupling map was `None` which implies all to all connectivity. With this change, `StandardRB` treats gates with no coupling map as bidirectional.

This issue first surfaced with qiskit-aer 0.13.0 which made `AerSimulator` a `BackendV2` backend (https://github.com/Qiskit-Extensions/qiskit-experiments/issues/1292).