### PR TITLE
Set noise model basis gates for tomography tests

### DIFF
--- a/test/library/tomography/tomo_utils.py
+++ b/test/library/tomography/tomo_utils.py
@@ -87,7 +87,9 @@ def readout_noise_model(num_qubits, seed=None):
     p1g0s = 0.15 * rng.random(num_qubits)
     p0g1s = 0.3 * rng.random(num_qubits)
     amats = np.stack([[1 - p1g0s, p1g0s], [p0g1s, 1 - p0g1s]]).T
-    noise_model = NoiseModel()
+    # Set `basis_gates` so that reset is included.
+    # See https://github.com/Qiskit/qiskit-aer/issues/1975
+    noise_model = NoiseModel(basis_gates=["id", "rz", "sx", "cx", "reset"])
     for i, amat in enumerate(amats):
         noise_model.add_readout_error(amat.T, [i])
     return noise_model


### PR DESCRIPTION
This sets the basis gates explicitly on the `NoiseModel` used for some tomography tests. Without this, some of the test circuits fail to transpile because `reset` is not in the equivalence library when using qiskit-aer 0.13.0 (see https://github.com/Qiskit/qiskit-aer/issues/1975).
