### PR TITLE
Setting type for composite experiment

### DIFF
--- a/qiskit_experiments/framework/base_experiment.py
+++ b/qiskit_experiments/framework/base_experiment.py
@@ -53,7 +53,7 @@ class BaseExperiment(ABC, StoreInitArgs):
             QiskitError: If qubits contains duplicates.
         """
         # Experiment identification metadata
-        self._type = experiment_type if experiment_type else type(self).__name__
+        self.experiment_type = experiment_type
 
         # Circuit parameters
         self._num_qubits = len(physical_qubits)
@@ -89,6 +89,14 @@ class BaseExperiment(ABC, StoreInitArgs):
     def experiment_type(self) -> str:
         """Return experiment type."""
         return self._type
+
+    @experiment_type.setter
+    def experiment_type(self, exp_type: str) -> None:
+        """Set the type for the experiment."""
+        if exp_type is None:
+            self._type = type(self).__name__
+        else:
+            self._type = exp_type
 
     @property
     def physical_qubits(self) -> Tuple[int, ...]:

--- a/qiskit_experiments/framework/composite/batch_experiment.py
+++ b/qiskit_experiments/framework/composite/batch_experiment.py
@@ -49,6 +49,7 @@ class BatchExperiment(CompositeExperiment):
         backend: Optional[Backend] = None,
         flatten_results: bool = None,
         analysis: Optional[CompositeAnalysis] = None,
+        experiment_type: Optional[str] = None,
     ):
         """Initialize a batch experiment.
 

--- a/qiskit_experiments/framework/composite/batch_experiment.py
+++ b/qiskit_experiments/framework/composite/batch_experiment.py
@@ -87,7 +87,12 @@ class BatchExperiment(CompositeExperiment):
                     logical_qubit += 1
         qubits = tuple(self._qubit_map.keys())
         super().__init__(
-            experiments, qubits, backend=backend, analysis=analysis, flatten_results=flatten_results
+            experiments,
+            qubits,
+            backend=backend,
+            analysis=analysis,
+            flatten_results=flatten_results,
+            experiment_type=experiment_type,
         )
 
     def circuits(self):

--- a/qiskit_experiments/framework/composite/parallel_experiment.py
+++ b/qiskit_experiments/framework/composite/parallel_experiment.py
@@ -80,7 +80,12 @@ class ParallelExperiment(CompositeExperiment):
         for exp in experiments:
             qubits += exp.physical_qubits
         super().__init__(
-            experiments, qubits, backend=backend, analysis=analysis, flatten_results=flatten_results
+            experiments,
+            qubits,
+            backend=backend,
+            analysis=analysis,
+            flatten_results=flatten_results,
+            experiment_type=experiment_type,
         )
 
     def circuits(self):

--- a/qiskit_experiments/framework/composite/parallel_experiment.py
+++ b/qiskit_experiments/framework/composite/parallel_experiment.py
@@ -49,6 +49,7 @@ class ParallelExperiment(CompositeExperiment):
         backend: Optional[Backend] = None,
         flatten_results: bool = None,
         analysis: Optional[CompositeAnalysis] = None,
+        experiment_type: Optional[str] = None,
     ):
         """Initialize the analysis object.
 

--- a/releasenotes/notes/setter-methods-for-experiment-099074e59faffb49.yaml
+++ b/releasenotes/notes/setter-methods-for-experiment-099074e59faffb49.yaml
@@ -1,9 +1,8 @@
 ---
 features:
   - |
-    Added ``experiment_type`` as optional ``__init__`` kwarg in BatchExperiment
-    and ParallelExperiment.
+    Added ``experiment_type`` as optional ``__init__`` kwarg in :class:`.BatchExperiment`
+    and :class:`.ParallelExperiment`.
   - |
-    :math:`BaseExperiment.experiment_type` as setter,'experiment_type' can now
-    be easily set and retrieved from the experiment object post-construction
-    using the 'experiment_type' property and setter.
+    :math:'experiment_type' can now be easily set and retrieved from the experiment
+    object post-construction using the 'experiment_type' property and setter.

--- a/releasenotes/notes/setter-methods-for-experiment-099074e59faffb49.yaml
+++ b/releasenotes/notes/setter-methods-for-experiment-099074e59faffb49.yaml
@@ -1,0 +1,9 @@
+---
+features:
+  - |
+    Added ``experiment_type`` as optional ``__init__`` kwarg in BatchExperiment
+    and ParallelExperiment.
+  - |
+    :math:`BaseExperiment.experiment_type` as setter,'experiment_type' can now
+    be easily set and retrieved from the experiment object post-construction
+    using the 'experiment_type' property and setter.

--- a/requirements-extras.txt
+++ b/requirements-extras.txt
@@ -1,5 +1,5 @@
 qiskit-ibm-provider>=0.6.1 # for submitting experiments to backends through the IBM provider
 cvxpy>=1.3.2 # for tomography
 scikit-learn # for discriminators
-qiskit-aer>=0.11.0,<=0.12.2 # Temporary version pin because of https://github.com/Qiskit-Extensions/qiskit-experiments/issues/1292
+qiskit-aer>=0.11.0
 qiskit_dynamics>=0.4.0 # for the PulseBackend

--- a/test/framework/test_composite.py
+++ b/test/framework/test_composite.py
@@ -151,6 +151,21 @@ class TestComposite(QiskitExperimentsTestCase):
 
         self.assertRoundTripSerializable(exp)
 
+    def test_experiment_type(self):
+        """Test experiment_type setter."""
+
+        exp1 = FakeExperiment([0])
+
+        par_exp1 = ParallelExperiment([exp1], flatten_results=False)
+        batch_exp1 = BatchExperiment([exp1], flatten_results=False)
+        self.assertEqual(par_exp1.experiment_type, "ParallelExperiment")
+        self.assertEqual(batch_exp1.experiment_type, "BatchExperiment")
+
+        par_exp2 = ParallelExperiment([exp1], flatten_results=False, experiment_type="yooo")
+        batch_exp2 = BatchExperiment([exp1], flatten_results=False, experiment_type="blaaa")
+        self.assertEqual(par_exp2.experiment_type, "yooo")
+        self.assertEqual(batch_exp2.experiment_type, "blaaa")
+
 
 @ddt
 class TestCompositeExperimentData(QiskitExperimentsTestCase):

--- a/test/framework/test_framework.py
+++ b/test/framework/test_framework.py
@@ -356,5 +356,6 @@ class TestFramework(QiskitExperimentsTestCase):
         exp1 = MyExp(physical_qubits=[0], experiment_type="blaaa")
         self.assertEqual(exp1.experiment_type, "blaaa")
         exp2 = MyExp(physical_qubits=[0])
+        self.assertEqual(exp2.experiment_type, "MyExp")
         exp2.experiment_type = "suieee"
         self.assertEqual(exp2.experiment_type, "suieee")

--- a/test/framework/test_framework.py
+++ b/test/framework/test_framework.py
@@ -340,3 +340,21 @@ class TestFramework(QiskitExperimentsTestCase):
         }
 
         self.assertEqual(exp.job_info(backend=backend), job_info)
+
+    def test_experiment_type(self):
+        """Test the experiment_type setter for the experiment."""
+
+        class MyExp(BaseExperiment):
+            """Some arbitrary experiment"""
+
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+
+            def circuits(self):
+                pass
+
+        exp1 = MyExp(physical_qubits=[0], experiment_type="blaaa")
+        self.assertEqual(exp1.experiment_type, "blaaa")
+        exp2 = MyExp(physical_qubits=[0])
+        exp2.experiment_type = "suieee"
+        self.assertEqual(exp2.experiment_type, "suieee")


### PR DESCRIPTION
### Summary

This PR solves issue #1289 

Added `experiment_type` property and setter in `BatchExperiment` and `ParallelExperiment` also added `experiment_type` setter in `BaseExperiment`, this changes will provide user flexibility and ease of use within their applications.

### PR checklist (delete when all criteria are met)

- [X] I have read the contributing guide `CONTRIBUTING.md`.
- [X] I have added the tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have added a release note file using `reno` if this change needs to be documented in the release notes.
