### PR TITLE
Cap qiskit-aer version in extra dependency (Backport of #1291)

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,7 +13,7 @@ reno>=4.0.0
 nbsphinx
 arxiv
 ddt>=1.6.0
-qiskit-aer>=0.11.0
+qiskit-aer>=0.11.0,<=0.12.2 # Temporary version pin because of https://github.com/Qiskit-Extensions/qiskit-experiments/issues/1292
 pandas>=1.1.5
 cvxpy>=1.1.15
 pylatexenc

--- a/test/visualization/test_plotter_mpldrawer.py
+++ b/test/visualization/test_plotter_mpldrawer.py
@@ -108,9 +108,10 @@ class TestPlotterAndMplDrawer(QiskitExperimentsTestCase):
         """
 
         # Create Matplotlib axes that use a PNG backend. The default backend, FigureCanvasSVG, does not
-        # have `tostring_rgb()` which is needed to compute the difference between two figures in this
+        # have `buffer_rgba()` which is needed to compute the difference between two figures in this
         # method. We need to set the axes as MplDrawer will use
         # `qiskit_experiments.framework.matplotlib.get_non_gui_ax` by default; which uses an SVG backend.
+        plt.close("all")
         plt.switch_backend("Agg")
         axes = {}
         for key in series_names.keys():
@@ -151,16 +152,12 @@ class TestPlotterAndMplDrawer(QiskitExperimentsTestCase):
                 for plot_type in legend_plot_types:
                     plotter.enable_legend_for(series_name, plot_type)
 
-        # Generate figure and save to buffers for comparison. This requires a pixel backend, like AGG, so
-        # that `tostring_rgb()` is available.
+        # Generate figure and save to buffers for comparison.
         figure_data = {}
         for plotter_type, plotter in plotters.items():
             figure = plotter.figure().figure
             figure.canvas.draw()
-            figure_data[plotter_type] = np.frombuffer(
-                figure.canvas.tostring_rgb(),
-                dtype=np.uint8,
-            ).reshape(figure.canvas.get_width_height() + (3,))
+            figure_data[plotter_type] = np.asarray(figure.canvas.buffer_rgba(), dtype=np.uint8)
 
         # Compare root-mean-squared error between two images.
         for (fig1_type, fig1), (fig2_type, fig2) in combinations(figure_data.items(), 2):


### PR DESCRIPTION
I found currently all PRs including the main branch fail in CI due to QPT/QST unittest including reset instruction. Likely this is due to qiskit-aer 0.13. I added version cap not to install this version as a temporary fix.