### PR TITLE
completion_times property fix

### DIFF
--- a/qiskit_experiments/framework/experiment_data.py
+++ b/qiskit_experiments/framework/experiment_data.py
@@ -379,8 +379,10 @@ class ExperimentData:
         """Returns the completion times of the jobs."""
         job_times = {}
         for job_id, job in self._jobs.items():
-            if job is not None and "COMPLETED" in job.time_per_step():
-                job_times[job_id] = job.time_per_step().get("COMPLETED")
+            if job is not None:
+                job_times[job_id] = job.time_per_step().get(
+                    "COMPLETED", None
+                ) or job.time_per_step().get("finished", None)
 
         return job_times
 


### PR DESCRIPTION
### Summary
This PR updates the way the `completion_times` property of `ExperimentData` is calculated to allow for the current format used by `IBMJob`.

### Details and comments
Fixes #1205 
