### PR TITLE
Increase timeout for Mac CI

### DIFF
--- a/.github/workflows/cron-staging.yml
+++ b/.github/workflows/cron-staging.yml
@@ -36,11 +36,12 @@ jobs:
             ${{ runner.os }}-${{ matrix.python-version }}
       - name: Install Deps
         run: python -m pip install -U tox setuptools virtualenv wheel
-      - name: Install and Run Tests
+        - name: Install and Run Tests (Windows and Linux)
         run: tox -e terra-main
         if: runner.os != 'macOS'
-      - name: Install and Run Tests
+      - name: Install and Run Tests (Macs only)
         run: tox -e terra-main
         if: runner.os == 'macOS'
         env:
+          TEST_TIMEOUT: 120
           OMP_NUM_THREADS: 1

--- a/.github/workflows/cron-staging.yml
+++ b/.github/workflows/cron-staging.yml
@@ -36,7 +36,7 @@ jobs:
             ${{ runner.os }}-${{ matrix.python-version }}
       - name: Install Deps
         run: python -m pip install -U tox setuptools virtualenv wheel
-        - name: Install and Run Tests (Windows and Linux)
+      - name: Install and Run Tests (Windows and Linux)
         run: tox -e terra-main
         if: runner.os != 'macOS'
       - name: Install and Run Tests (Macs only)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,6 +57,7 @@ jobs:
         if: runner.os == 'macOS'
         env:
           TEST_TIMEOUT: 120
+          OMP_NUM_THREADS: 1
       - name: Clean up stestr cache
         run: stestr history remove all
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,8 +49,14 @@ jobs:
             stestr-
       - name: Install Deps
         run: python -m pip install -U tox setuptools virtualenv wheel stestr
-      - name: Install and Run Tests
+      - name: Install and Run Tests (Windows and Linux)
         run: tox -e py
+        if: runner.os != 'macOS'
+      - name: Install and Run Tests (Macs only)
+        run: tox -e py
+        if: runner.os == 'macOS'
+        env:
+          TEST_TIMEOUT: 120
       - name: Clean up stestr cache
         run: stestr history remove all
 

--- a/test/base.py
+++ b/test/base.py
@@ -33,7 +33,7 @@ from qiskit_experiments.framework.experiment_data import ExperimentStatus
 from .extended_equality import is_equivalent
 
 # Fail tests that take longer than this
-TEST_TIMEOUT = os.environ.get("TEST_TIMEOUT", 60)
+TEST_TIMEOUT = int(os.environ.get("TEST_TIMEOUT", 60))
 
 
 class QiskitExperimentsTestCase(QiskitTestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,7 @@ passenv =
   QISKIT_PARALLEL
   RAYON_NUM_THREADS
   QISKIT_IBM_*
+  TEST_TIMEOUT
 commands = stestr run {posargs}
 
 [testenv:cover]


### PR DESCRIPTION
### Summary

Mac CI tests can take significantly longer than Windows and Linux. This PR doubles the timeout for Mac tests so they don't fail as frequently and adds back the `OMP_NUM_THREADS: 1` option, which seems to help reduce individual test times.