### PR TITLE
Update pylint to version 3.0

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -70,6 +70,9 @@ disable=fixme,              # disabled as TODOs would show up as warnings
     no-else-return,     # relax "elif" after a clause with a return
     docstring-first-line-empty, # relax docstring style
     import-outside-toplevel,
+    cyclic-import,  # This checker raises on all module pairs that import each other,
+                    # even submodules that only import already loaded objects from a
+                    # parent module, a common pattern in qiskit-experiments.
     assigning-non-slot  # https://github.com/Qiskit/qiskit-terra/pull/7347#issuecomment-985007311
 
 

--- a/qiskit_experiments/framework/experiment_data.py
+++ b/qiskit_experiments/framework/experiment_data.py
@@ -196,7 +196,7 @@ class FigureData:
         return None
 
 
-_FigureT = Union[str, bytes, MatplotlibFigure, FigureData]
+FigureT = Union[str, bytes, MatplotlibFigure, FigureData]
 
 
 class ExperimentData:
@@ -1134,7 +1134,7 @@ class ExperimentData:
     @do_auto_save
     def add_figures(
         self,
-        figures: Union[_FigureT, List[_FigureT]],
+        figures: Union[FigureT, List[FigureT]],
         figure_names: Optional[Union[str, List[str]]] = None,
         overwrite: bool = False,
         save_figure: Optional[bool] = None,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 black~=22.0
 stestr
-pylint~=2.16.2
-astroid~=2.14.2  # Must be kept aligned to what pylint wants
+pylint~=3.0.2
+astroid~=3.0.1  # Must be kept aligned to what pylint wants
 jinja2==3.0.3
 sphinx>=6.2.1,<=7
 jupyter-sphinx>=0.4.0

--- a/tox.ini
+++ b/tox.ini
@@ -51,8 +51,8 @@ commands = stestr run {posargs}
 [testenv:lint]
 envdir = .tox/lint
 commands =
-  black --check {posargs} qiskit_experiments test tools setup.py
-  pylint -rn -j 0 --rcfile={toxinidir}/.pylintrc qiskit_experiments/ test/ tools/
+  black --check qiskit_experiments test tools setup.py
+  pylint -rn {posargs} --rcfile={toxinidir}/.pylintrc qiskit_experiments/ test/ tools/
   python {toxinidir}/tools/verify_headers.py
 
 [testenv:lint-incr]
@@ -62,7 +62,7 @@ allowlist_externals = git
 commands =
   black --check {posargs} qiskit_experiments test tools setup.py
   -git fetch -q https://github.com/Qiskit-Extensions/qiskit-experiments :lint_incr_latest
-  python {toxinidir}/tools/pylint_incr.py -rn -j4 -sn --paths :/qiskit_experiments/*.py :/test/*.py :/tools/*.py
+  python {toxinidir}/tools/pylint_incr.py -rn {posargs} -sn --paths :/qiskit_experiments/*.py :/test/*.py :/tools/*.py
   python {toxinidir}/tools/verify_headers.py qiskit_experiments test tools
 
 [testenv:black]


### PR DESCRIPTION
* Remove leading `_` from type alias (since it is type annotations it is effectively a public name)
* Disable the cyclic import checker. By its definition, we do have cyclic imports. pylint seems not to find them when using multiple processes but it does find them when using a single process.
* Remove default parallelism from tox pylint runs and from the CI run
* Move `posargs` from black to pylint in the tox lint commands so that parallelism can be used optionally