### PR TITLE
Bugfix when copying the `ExperiemntData` object and add warning to `_retrievve_data`

### DIFF
--- a/qiskit_experiments/framework/experiment_data.py
+++ b/qiskit_experiments/framework/experiment_data.py
@@ -1071,6 +1071,7 @@ class ExperimentData:
         """Retrieve job data if missing experiment data."""
         # Get job results if missing in experiment data.
         if self.provider is None:
+            LOG.warning("provider is None, no data was retrieved.")
             return
         retrieved_jobs = {}
         jobs_to_retrieve = []  # the list of all jobs to retrieve from the server
@@ -2293,6 +2294,7 @@ class ExperimentData:
         new_instance = ExperimentData(
             backend=self.backend,
             service=self.service,
+            provider=self.provider,
             parent_id=self.parent_id,
             job_ids=self.job_ids,
             child_data=list(self._child_data.values()),


### PR DESCRIPTION
### Summary

`Copy` method in `Experiment Data` class will now copy the `provider` attribute to the copied instance and warnning if data isn't retrieved due to `provider=None` 
### Details and comments

Some details that should be in this section include:

- Why this change was necessary
This is a bug that the provider isn't copied. In addition, `_retrive_data()` method in the `ExperimentData` class doesn;t retirive data if provider is not provided. Added a warning so the user will know.


### PR checklist (delete when all criteria are met)

- [x] I have read the contributing guide `CONTRIBUTING.md`.
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a release note file using `reno` if this change needs to be documented in the release notes.
