### PR TITLE
Improve performance of RB circuit generation

### DIFF
--- a/qiskit_experiments/library/randomized_benchmarking/standard_rb.py
+++ b/qiskit_experiments/library/randomized_benchmarking/standard_rb.py
@@ -22,7 +22,7 @@ import numpy as np
 from numpy.random import Generator, default_rng
 from numpy.random.bit_generator import BitGenerator, SeedSequence
 
-from qiskit.circuit import QuantumCircuit, Instruction, Barrier
+from qiskit.circuit import CircuitInstruction, QuantumCircuit, Instruction, Barrier
 from qiskit.exceptions import QiskitError
 from qiskit.providers import BackendV2Converter
 from qiskit.providers.backend import Backend, BackendV1, BackendV2
@@ -291,7 +291,7 @@ class StandardRB(BaseExperiment, RestlessMixin):
             circ = QuantumCircuit(self.num_qubits)
             for elem in seq:
                 circ.append(self._to_instruction(elem, basis_gates), circ.qubits)
-                circ._append(Barrier(self.num_qubits), circ.qubits, circ.cregs)
+                circ._append(CircuitInstruction(Barrier(self.num_qubits), circ.qubits) )
 
             # Compute inverse, compute only the difference from the previous shorter sequence
             prev_elem = self.__compose_clifford_seq(prev_elem, seq[len(prev_seq) :])

--- a/qiskit_experiments/library/randomized_benchmarking/standard_rb.py
+++ b/qiskit_experiments/library/randomized_benchmarking/standard_rb.py
@@ -291,7 +291,7 @@ class StandardRB(BaseExperiment, RestlessMixin):
             circ = QuantumCircuit(self.num_qubits)
             for elem in seq:
                 circ.append(self._to_instruction(elem, basis_gates), circ.qubits)
-                circ._append(CircuitInstruction(Barrier(self.num_qubits), circ.qubits) )
+                circ._append(CircuitInstruction(Barrier(self.num_qubits), circ.qubits))
 
             # Compute inverse, compute only the difference from the previous shorter sequence
             prev_elem = self.__compose_clifford_seq(prev_elem, seq[len(prev_seq) :])

--- a/qiskit_experiments/library/randomized_benchmarking/standard_rb.py
+++ b/qiskit_experiments/library/randomized_benchmarking/standard_rb.py
@@ -291,7 +291,7 @@ class StandardRB(BaseExperiment, RestlessMixin):
             circ = QuantumCircuit(self.num_qubits)
             for elem in seq:
                 circ.append(self._to_instruction(elem, basis_gates), circ.qubits)
-                circ.append(Barrier(self.num_qubits), circ.qubits)
+                circ._append(Barrier(self.num_qubits), circ.qubits, circ.cregs)
 
             # Compute inverse, compute only the difference from the previous shorter sequence
             prev_elem = self.__compose_clifford_seq(prev_elem, seq[len(prev_seq) :])


### PR DESCRIPTION
### Summary

In this PR we improve performance of the RB circuit generation.

### Details and comments

The main performance bottleneck is the repeat application of `append` of sequence elements to a circuit. We can improve performance by using the `_append` for the `Barrier` gate.

For the appending of the Clifford gates we could also use `_append` (in particular if the sequence elements are integral, in which case the internal generation using `_to_instruction` guarantees the elements to not need checking), but since the `StandardRB` is subclassed we have no full information about the elements in the sequence and have chosen not to do this.

Profiling on main:

![image](https://github.com/Qiskit-Extensions/qiskit-experiments/assets/883786/23ddd6b3-e3cb-4ade-914f-45e197b0d0c7)

PR:

![image](https://github.com/Qiskit-Extensions/qiskit-experiments/assets/883786/81714750-6f33-4410-aa4f-c14287bc8dd8)


### PR checklist (delete when all criteria are met)

- [x] I have read the contributing guide `CONTRIBUTING.md`.
- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have added a release note file using `reno` if this change needs to be documented in the release notes. Internal change, no release notes needed
