### PR TITLE
Replace qiskit-terra references with qiskit references

### DIFF
--- a/.github/workflows/cron-staging.yml
+++ b/.github/workflows/cron-staging.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  terra-main-tests:
+  qiskit-main-tests:
     name: tests-python${{ matrix.python-version }}-${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -37,10 +37,10 @@ jobs:
       - name: Install Deps
         run: python -m pip install -U tox setuptools virtualenv wheel
       - name: Install and Run Tests (Windows and Linux)
-        run: tox -e terra-main
+        run: tox -e qiskit-main
         if: runner.os != 'macOS'
       - name: Install and Run Tests (Macs only)
-        run: tox -e terra-main
+        run: tox -e qiskit-main
         if: runner.os == 'macOS'
         env:
           TEST_TIMEOUT: 120
@@ -66,7 +66,7 @@ jobs:
           python -m pip install -U tox
           sudo apt-get install -y pandoc graphviz
       - name: Build Docs
-        run: tox -edocs-terra-main
+        run: tox -edocs-qiskit-main
       - name: Compress Artifacts
         run: |
           mkdir artifacts

--- a/.pylintrc
+++ b/.pylintrc
@@ -73,7 +73,7 @@ disable=fixme,              # disabled as TODOs would show up as warnings
     cyclic-import,  # This checker raises on all module pairs that import each other,
                     # even submodules that only import already loaded objects from a
                     # parent module, a common pattern in qiskit-experiments.
-    assigning-non-slot  # https://github.com/Qiskit/qiskit-terra/pull/7347#issuecomment-985007311
+    assigning-non-slot  # https://github.com/Qiskit/qiskit/pull/7347#issuecomment-985007311
 
 
 

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,4 +1,4 @@
 # Numpy 1.25 deprecated some behaviours that we used, and caused some
-# tests to flake. See https://github.com/Qiskit/qiskit-terra/issues/10305,
+# tests to flake. See https://github.com/Qiskit/qiskit/issues/10305,
 # remove pin when resolving that.
 numpy<1.25

--- a/qiskit_experiments/database_service/utils.py
+++ b/qiskit_experiments/database_service/utils.py
@@ -12,6 +12,7 @@
 
 """Experiment utility functions."""
 
+import importlib.metadata
 import io
 import logging
 import threading
@@ -26,25 +27,19 @@ import dateutil.parser
 import pkg_resources
 from dateutil import tz
 
-from qiskit.version import __version__ as terra_version
-
 from qiskit_ibm_experiment import (
     IBMExperimentEntryExists,
     IBMExperimentEntryNotFound,
 )
 
 from .exceptions import ExperimentEntryNotFound, ExperimentEntryExists, ExperimentDataError
-from ..version import __version__ as experiments_version
 
 LOG = logging.getLogger(__name__)
 
 
 def qiskit_version():
     """Return the Qiskit version."""
-    try:
-        return pkg_resources.get_distribution("qiskit").version
-    except Exception:  # pylint: disable=broad-except
-        return {"qiskit-terra": terra_version, "qiskit-experiments": experiments_version}
+    return importlib.metadata.distribution("qiskit").version
 
 
 def parse_timestamp(utc_dt: Union[datetime, str]) -> datetime:

--- a/qiskit_experiments/database_service/utils.py
+++ b/qiskit_experiments/database_service/utils.py
@@ -38,7 +38,7 @@ LOG = logging.getLogger(__name__)
 
 def qiskit_version():
     """Return the Qiskit version."""
-    return importlib.metadata.distribution("qiskit").version
+    return {p: importlib.metadata.distribution(p).version for p in ("qiskit", "qiskit-experiments")}
 
 
 def parse_timestamp(utc_dt: Union[datetime, str]) -> datetime:

--- a/qiskit_experiments/database_service/utils.py
+++ b/qiskit_experiments/database_service/utils.py
@@ -24,7 +24,6 @@ from typing import Callable, Tuple, Dict, Any, Union, Type, Optional
 import json
 
 import dateutil.parser
-import pkg_resources
 from dateutil import tz
 
 from qiskit_ibm_experiment import (

--- a/qiskit_experiments/framework/backend_data.py
+++ b/qiskit_experiments/framework/backend_data.py
@@ -32,10 +32,10 @@ class BackendData:
             self._parse_additional_data()
 
     def _parse_additional_data(self):
-        # data specific parsing not done yet in qiskit-terra
+        # data specific parsing not done yet in upstream qiskit
         if hasattr(self._backend, "_conf_dict") and self._backend._conf_dict["open_pulse"]:
             if "u_channel_lo" not in self._backend._conf_dict:
-                self._backend._conf_dict["u_channel_lo"] = []  # to avoid terra bug
+                self._backend._conf_dict["u_channel_lo"] = []  # to avoid qiskit bug
             self._pulse_conf = PulseBackendConfiguration.from_dict(self._backend._conf_dict)
 
     @property
@@ -222,7 +222,7 @@ class BackendData:
 
         .. note::
 
-            The qiskit-terra base classes do not provide this information as a
+            The qiskit base classes do not provide this information as a
             standard backend property, but it is available from some providers
             in the data returned by the ``Backend.defaults()`` method.
         """
@@ -249,7 +249,7 @@ class BackendData:
             For `BackendV2` we sometimes cannot be sure, because it lacks
             a `simulator` field, as was present in `BackendV1`'s configuration.
             We still check whether the backend inherits `FakeBackendV2`, for
-            either of its existing implementations in Terra.
+            either of its existing implementations in Qiskit.
         """
         if self._v1:
             if self._backend.configuration().simulator or isinstance(self._backend, FakeBackend):

--- a/qiskit_experiments/framework/backend_data.py
+++ b/qiskit_experiments/framework/backend_data.py
@@ -146,10 +146,7 @@ class BackendData:
             if self._v1:
                 return self._backend.configuration().timing_constraints.get("acquire_alignment", 1)
             elif self._v2:
-                # currently has a typo in terra
-                if hasattr(self._backend.target, "acquire_alignment"):
-                    return self._backend.target.acquire_alignment
-                return self._backend.target.aquire_alignment
+                return self._backend.target.acquire_alignment
         except AttributeError:
             return 1
         return 1

--- a/qiskit_experiments/library/randomized_benchmarking/data/generate_clifford_data.py
+++ b/qiskit_experiments/library/randomized_benchmarking/data/generate_clifford_data.py
@@ -16,8 +16,6 @@ This file is a stand-alone script for generating the npz files in
 The script relies on the values of ``_CLIFF_SINGLE_GATE_MAP_2Q``
 in :mod:`~qiskit_experiment.library.randomized_benchmarking.clifford_utils`
 so they must be set correctly before running the script.
-
-Note: Terra >= 0.22 is required to run this script.
 """
 import itertools
 

--- a/releasenotes/notes/qiskit-dependency-3f6b8d71cc4d2c31.yaml
+++ b/releasenotes/notes/qiskit-dependency-3f6b8d71cc4d2c31.yaml
@@ -5,8 +5,11 @@ upgrade:
     ``qiskit``. This change follows the move in upstream Qiskit to rename
     ``qiskit-terra`` to ``qiskit``. The minimum required version was increased
     from 0.24 for ``qiskit-terra`` to 0.44 for ``qiskit`` (equivalent to
-    `qiskit-terra`` 0.25).For more information see `the Qiskit repository
-    renaming plan
+    `qiskit-terra`` 0.25). The maximum ``qiskit`` version was set to ``<1.0``
+    in anticipation of breaking changes in Qiskit 1.0. Closer to the Qiskit 1.0
+    release, a patch release of ``qiskit-experiments`` will remove this
+    constraint and address any compatibility issues. For more information see
+    the `Qiskit repository renaming plan
     <https://github.com/Qiskit/RFCs/blob/5793e78dc8e4d8d17f8ef7fad789c6c5ebd3a061/0011-repo-rename.md>`__
     and the `Qiskit issue <https://github.com/Qiskit/qiskit/issues/11240>`__
     for the renaming of the package.

--- a/releasenotes/notes/qiskit-dependency-3f6b8d71cc4d2c31.yaml
+++ b/releasenotes/notes/qiskit-dependency-3f6b8d71cc4d2c31.yaml
@@ -1,0 +1,10 @@
+---
+upgrade:
+  - |
+    The dependency on ``qiskit-terra`` was replaced with a dependency on
+    ``qiskit``. This change follows move in upstream Qiskit to rename
+    ``qiskit-terra`` to ``qiskit``. For more information see `the Qiskit
+    repository renaming plan
+    <https://github.com/Qiskit/RFCs/blob/5793e78dc8e4d8d17f8ef7fad789c6c5ebd3a061/0011-repo-rename.md>`__
+    and the `Qiskit issue <https://github.com/Qiskit/qiskit/issues/11240>`__
+    for the renaming of the package.

--- a/releasenotes/notes/qiskit-dependency-3f6b8d71cc4d2c31.yaml
+++ b/releasenotes/notes/qiskit-dependency-3f6b8d71cc4d2c31.yaml
@@ -2,7 +2,7 @@
 upgrade:
   - |
     The dependency on ``qiskit-terra`` was replaced with a dependency on
-    ``qiskit``. This change follows move in upstream Qiskit to rename
+    ``qiskit``. This change follows the move in upstream Qiskit to rename
     ``qiskit-terra`` to ``qiskit``. For more information see `the Qiskit
     repository renaming plan
     <https://github.com/Qiskit/RFCs/blob/5793e78dc8e4d8d17f8ef7fad789c6c5ebd3a061/0011-repo-rename.md>`__

--- a/releasenotes/notes/qiskit-dependency-3f6b8d71cc4d2c31.yaml
+++ b/releasenotes/notes/qiskit-dependency-3f6b8d71cc4d2c31.yaml
@@ -3,8 +3,10 @@ upgrade:
   - |
     The dependency on ``qiskit-terra`` was replaced with a dependency on
     ``qiskit``. This change follows the move in upstream Qiskit to rename
-    ``qiskit-terra`` to ``qiskit``. For more information see `the Qiskit
-    repository renaming plan
+    ``qiskit-terra`` to ``qiskit``. The minimum required version was increased
+    from 0.24 for ``qiskit-terra`` to 0.44 for ``qiskit`` (equivalent to
+    `qiskit-terra`` 0.25).For more information see `the Qiskit repository
+    renaming plan
     <https://github.com/Qiskit/RFCs/blob/5793e78dc8e4d8d17f8ef7fad789c6c5ebd3a061/0011-repo-rename.md>`__
     and the `Qiskit issue <https://github.com/Qiskit/qiskit/issues/11240>`__
     for the renaming of the package.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-qiskit-terra>=0.45.0
+qiskit>=0.45.0
 black~=22.0
 fixtures
 stestr

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy>=1.17
 scipy>=1.4
-qiskit-terra>=0.24
+qiskit>=0.44
 qiskit-ibm-experiment>=0.3.4
 matplotlib>=3.4
 uncertainties

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy>=1.17
 scipy>=1.4
-qiskit>=0.44
+qiskit>=0.44,<1.0
 qiskit-ibm-experiment>=0.3.4
 matplotlib>=3.4
 uncertainties

--- a/test/framework/test_backend_timing.py
+++ b/test/framework/test_backend_timing.py
@@ -18,7 +18,7 @@ from ddt import data, ddt, unpack
 from qiskit import QiskitError
 from qiskit.providers.fake_provider import FakeNairobiV2
 
-from qiskit_experiments.framework import BackendData, BackendTiming
+from qiskit_experiments.framework import BackendTiming
 
 
 @ddt

--- a/test/framework/test_backend_timing.py
+++ b/test/framework/test_backend_timing.py
@@ -33,13 +33,10 @@ class TestBackendTiming(QiskitExperimentsTestCase):
         # terra. Just to be safe, we check that the properties we care about
         # for these tests are never changed from what the tests assume.
         backend = FakeNairobiV2()
-        # Using BackendData to handle acquire/aquire rename. Can replace with
-        # target.acquire_alignment when testing against terra >=0.24
-        backend_data = BackendData(backend)
         target = backend.target
         assumptions = (
             (abs(target.dt * 4.5e9 - 1) < 1e-6)
-            and backend_data.acquire_alignment == 16
+            and target.acquire_alignment == 16
             and target.pulse_alignment == 1
             and target.min_length == 64
             and target.granularity == 16
@@ -47,7 +44,7 @@ class TestBackendTiming(QiskitExperimentsTestCase):
         if not assumptions:  # pragma: no cover
             raise ValueError("FakeNairobiV2 properties have changed!")
 
-        cls.acquire_alignment = backend_data.acquire_alignment
+        cls.acquire_alignment = target.acquire_alignment
         cls.dt = target.dt
         cls.granularity = target.granularity
         cls.min_length = target.min_length

--- a/test/framework/test_backend_timing.py
+++ b/test/framework/test_backend_timing.py
@@ -30,7 +30,7 @@ class TestBackendTiming(QiskitExperimentsTestCase):
         super().setUpClass()
 
         # Creating a complete fake backend is difficult so we use one from
-        # terra. Just to be safe, we check that the properties we care about
+        # qiskit. Just to be safe, we check that the properties we care about
         # for these tests are never changed from what the tests assume.
         backend = FakeNairobiV2()
         target = backend.target

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,7 @@ commands =
     coverage3 combine
     coverage3 lcov
 
-[testenv:terra-main]
+[testenv:qiskit-main]
 usedevelop = True
 install_command = pip install -U {opts} {packages}
 setenv =
@@ -106,7 +106,7 @@ setenv =
 commands =
   sphinx-build -T -W --keep-going -b html {posargs} docs/ docs/_build/html
 
-[testenv:docs-terra-main]
+[testenv:docs-qiskit-main]
 usedevelop = True
 passenv =
   EXPERIMENTS_DEV_DOCS

--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,7 @@ setenv =
   QISKIT_SUPPRESS_PACKAGING_WARNINGS=Y
   QISKIT_TEST_CAPTURE_STREAMS=1
 deps =
-  git+https://github.com/Qiskit/qiskit-terra
+  git+https://github.com/Qiskit/qiskit
   -r{toxinidir}/requirements-dev.txt
   -r{toxinidir}/requirements-extras.txt
 passenv =
@@ -114,7 +114,7 @@ passenv =
   RELEASE_STRING
   VERSION_STRING
 deps =
-  git+https://github.com/Qiskit/qiskit-terra
+  git+https://github.com/Qiskit/qiskit
   -r{toxinidir}/requirements-dev.txt
   -r{toxinidir}/requirements-extras.txt
 commands =


### PR DESCRIPTION
This change brings qiskit-experiments in line with other packages like qiskit-ibm-provider and qiskit-aer and prepares for the deprecation of the qiskit-terra package.

Detailed changes:

* Replace qiskit-terra dependency with qiskit dependency
  - The effective minimum version of qiskit-terra is bumped up one minor version from 0.24 to 0.25 (linked to qiskit 0.44) as part of this change, but since qiskit 0.45 has already been released this should not be an impactful change for most users.
* Simplify the code for logging the version of qiskit used. It should always use the Qiskit version as a string. Previously, it could sometimes use a dictionary with the Qiskit and Qiskit Experiments versions.
* Remove workaround for `aquire_alignment` misspelling in old versions of terra (because it was commented referencing terra)
* Replace qiskit-terra in requirements-dev.txt and tox.ini
* Replace various references to "terra" in various code comments with "Qiskit"
* Rename terra-main and docs-terra-main tox environments to qiskit-main and docs-qiskit-main
* Rename GitHub workflow job terra-main-tests to qiskit-main-tests

The only remaining references to "terra" in the codebase are in old release notes.