### PR TITLE
Remove constraint on numpy version from tox.ini

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,4 +1,0 @@
-# Numpy 1.25 deprecated some behaviours that we used, and caused some
-# tests to flake. See https://github.com/Qiskit/qiskit-terra/issues/10305,
-# remove pin when resolving that.
-numpy<1.25


### PR DESCRIPTION
numpy 1.25 had deprecated some functions used by Qiskit. Since the tests are set to fail if deprecation warnings are emitted, the numpy version was pinned while Qiskit worked on addressing the deprecated usage. Now that Qiskit has addressed these issues, the version constraint can be removed.