### PR TITLE
Fix qiskit-main tox environment

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy>=1.17
 scipy>=1.4
-qiskit>=0.44,<1.0
+qiskit>=0.44
 qiskit-ibm-experiment>=0.3.4
 matplotlib>=3.4
 uncertainties

--- a/tox.ini
+++ b/tox.ini
@@ -41,6 +41,7 @@ setenv =
   QISKIT_TEST_CAPTURE_STREAMS=1
 deps =
   git+https://github.com/Qiskit/qiskit
+  git+https://github.com/Qiskit/qiskit#subdirectory=qiskit_pkg
   -r{toxinidir}/requirements-dev.txt
   -r{toxinidir}/requirements-extras.txt
 passenv =
@@ -115,6 +116,7 @@ passenv =
   VERSION_STRING
 deps =
   git+https://github.com/Qiskit/qiskit
+  git+https://github.com/Qiskit/qiskit#subdirectory=qiskit_pkg
   -r{toxinidir}/requirements-dev.txt
   -r{toxinidir}/requirements-extras.txt
 commands =


### PR DESCRIPTION
* Install `qiskit` package as well as `qiskit-terra` package from upstream Qiskit repo.
* Remove upper bound on Qiskit version since the version provided by the upstream repo exceeds this bound. The bound can be restored in a release branch prior to release.