### PR TITLE
Revert Qiskit dependency change for CI

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-qiskit>=0.45.0
+qiskit-terra>=0.45.0
 black~=22.0
 fixtures
 stestr

--- a/tox.ini
+++ b/tox.ini
@@ -41,7 +41,6 @@ setenv =
   QISKIT_TEST_CAPTURE_STREAMS=1
 deps =
   git+https://github.com/Qiskit/qiskit
-  git+https://github.com/Qiskit/qiskit#subdirectory=qiskit_pkg
   -r{toxinidir}/requirements-dev.txt
   -r{toxinidir}/requirements-extras.txt
 passenv =
@@ -116,7 +115,6 @@ passenv =
   VERSION_STRING
 deps =
   git+https://github.com/Qiskit/qiskit
-  git+https://github.com/Qiskit/qiskit#subdirectory=qiskit_pkg
   -r{toxinidir}/requirements-dev.txt
   -r{toxinidir}/requirements-extras.txt
 commands =


### PR DESCRIPTION
The change in #1323 isn't working with tox 4. Since Qiskit's `qiskit_pkg` will be removed very soon, it's easier for us to revert back to `qiskit-terra` as the dependency temporarily until the update.