### PR TITLE
Fix pickle deserialization of ExperimentData

### DIFF
--- a/qiskit_experiments/framework/experiment_data.py
+++ b/qiskit_experiments/framework/experiment_data.py
@@ -2542,6 +2542,7 @@ class ExperimentData:
         self._job_futures = ThreadSafeOrderedDict()
         self._analysis_futures = ThreadSafeOrderedDict()
         self._analysis_executor = futures.ThreadPoolExecutor(max_workers=1)
+        self._monitor_executor = futures.ThreadPoolExecutor()
 
     def __str__(self):
         line = 51 * "-"

--- a/qiskit_experiments/framework/experiment_data.py
+++ b/qiskit_experiments/framework/experiment_data.py
@@ -196,7 +196,7 @@ class FigureData:
         return None
 
 
-FigureT = Union[str, bytes, MatplotlibFigure, FigureData]
+FigureType = Union[str, bytes, MatplotlibFigure, FigureData]
 
 
 class ExperimentData:
@@ -1134,7 +1134,7 @@ class ExperimentData:
     @do_auto_save
     def add_figures(
         self,
-        figures: Union[FigureT, List[FigureT]],
+        figures: Union[FigureType, List[FigureType]],
         figure_names: Optional[Union[str, List[str]]] = None,
         overwrite: bool = False,
         save_figure: Optional[bool] = None,

--- a/releasenotes/notes/exp-data-pickle-61511b6e926e3198.yaml
+++ b/releasenotes/notes/exp-data-pickle-61511b6e926e3198.yaml
@@ -2,7 +2,7 @@
 fixes:
   - |
     Fixed :mod:`pickle` deserialization of :class:`.ExperimentData` objects.
-    Previously, :class:`.ExperimentData` objects could serialized and
+    Previously, :class:`.ExperimentData` objects could be serialized and
     deserialized using Python's ``pickle`` module, but deserialized objects
     were not completely restored and an exception would be raised when doing
     some operations like running analysis on the restored object. See `#1326

--- a/releasenotes/notes/exp-data-pickle-61511b6e926e3198.yaml
+++ b/releasenotes/notes/exp-data-pickle-61511b6e926e3198.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Fixed :mod:`pickle` deserialization of :class:`.ExperimentData` objects.
+    Previously, :class:`.ExperimentData` objects could serialized and
+    deserialized using Python's ``pickle`` module, but deserialized objects
+    were not completely restored and an exception would be raised when doing
+    some operations like running analysis on the restored object. See `#1326
+    <https://github.com/Qiskit-Extensions/qiskit-experiments/pull/1326/files>`__.

--- a/test/base.py
+++ b/test/base.py
@@ -160,6 +160,7 @@ def create_base_test_case(use_testtools: bool) -> unittest.TestCase:
                 second: Second object to compare.
                 msg: Optional. Custom error message issued when first and second object are not equal.
                 strict_type: Set True to enforce type check before comparison.
+                kwargs: Additional options to pass through to ``is_equivalent``
             """
             default_msg = f"{first} != {second}"
 

--- a/test/base.py
+++ b/test/base.py
@@ -143,7 +143,7 @@ def create_base_test_case(use_testtools: bool) -> unittest.TestCase:
             *,
             msg: Optional[str] = None,
             strict_type: bool = False,
-            **kwargs
+            **kwargs,
         ):
             """Extended equality assertion which covers Qiskit Experiments classes.
 

--- a/test/base.py
+++ b/test/base.py
@@ -143,7 +143,6 @@ def create_base_test_case(use_testtools: bool) -> unittest.TestCase:
             *,
             msg: Optional[str] = None,
             strict_type: bool = False,
-            **kwargs,
         ):
             """Extended equality assertion which covers Qiskit Experiments classes.
 
@@ -165,7 +164,7 @@ def create_base_test_case(use_testtools: bool) -> unittest.TestCase:
             default_msg = f"{first} != {second}"
 
             self.assertTrue(
-                is_equivalent(first, second, strict_type=strict_type, **kwargs),
+                is_equivalent(first, second, strict_type=strict_type),
                 msg=msg or default_msg,
             )
 

--- a/test/base.py
+++ b/test/base.py
@@ -143,6 +143,7 @@ def create_base_test_case(use_testtools: bool) -> unittest.TestCase:
             *,
             msg: Optional[str] = None,
             strict_type: bool = False,
+            **kwargs
         ):
             """Extended equality assertion which covers Qiskit Experiments classes.
 
@@ -163,7 +164,7 @@ def create_base_test_case(use_testtools: bool) -> unittest.TestCase:
             default_msg = f"{first} != {second}"
 
             self.assertTrue(
-                is_equivalent(first, second, strict_type=strict_type),
+                is_equivalent(first, second, strict_type=strict_type, **kwargs),
                 msg=msg or default_msg,
             )
 

--- a/test/base.py
+++ b/test/base.py
@@ -159,7 +159,6 @@ def create_base_test_case(use_testtools: bool) -> unittest.TestCase:
                 second: Second object to compare.
                 msg: Optional. Custom error message issued when first and second object are not equal.
                 strict_type: Set True to enforce type check before comparison.
-                kwargs: Additional options to pass through to ``is_equivalent``
             """
             default_msg = f"{first} != {second}"
 

--- a/test/extended_equality.py
+++ b/test/extended_equality.py
@@ -60,6 +60,8 @@ def is_equivalent(
             e.g. iterator with the same element; tuple vs list,
             you can turn off this flag to relax the constraint for data type.
         numerical_precision: Tolerance of difference between two real numbers.
+        kwargs: Additional options to pass through to the type-specific
+            equivalence testing functions
 
     Returns:
         True when two objects are equivalent.

--- a/test/extended_equality.py
+++ b/test/extended_equality.py
@@ -307,11 +307,19 @@ def _check_result_table(
     # order.
     table1 = sorted(
         table1.values(),
-        key=lambda x: (x["name"], tuple(repr(d) for d in x["components"]), x["value"]),
+        key=lambda x: (
+            x["name"],
+            () if x["components"] is None else tuple(repr(d) for d in x["components"]),
+            x["value"],
+        ),
     )
     table2 = sorted(
         table2.values(),
-        key=lambda x: (x["name"], tuple(repr(d) for d in x["components"]), x["value"]),
+        key=lambda x: (
+            x["name"],
+            () if x["components"] is None else tuple(repr(d) for d in x["components"]),
+            x["value"],
+        ),
     )
     return is_equivalent(
         table1,

--- a/test/extended_equality.py
+++ b/test/extended_equality.py
@@ -64,8 +64,6 @@ def is_equivalent(
             e.g. iterator with the same element; tuple vs list,
             you can turn off this flag to relax the constraint for data type.
         numerical_precision: Tolerance of difference between two real numbers.
-        kwargs: Additional options to pass through to the type-specific
-            equivalence testing functions
 
     Returns:
         True when two objects are equivalent.

--- a/test/extended_equality.py
+++ b/test/extended_equality.py
@@ -42,12 +42,7 @@ from qiskit_experiments.visualization import BaseDrawer
 
 
 def is_equivalent(
-    data1: Any,
-    data2: Any,
-    *,
-    strict_type: bool = True,
-    numerical_precision: float = 1e-8,
-    **kwargs
+    data1: Any, data2: Any, *, strict_type: bool = True, numerical_precision: float = 1e-8, **kwargs
 ) -> bool:
     """Check if two input data are equivalent.
 
@@ -72,11 +67,7 @@ def is_equivalent(
     if strict_type and type(data1) is not type(data2):
         return False
     evaluated = _is_equivalent_dispatcher(
-        data1,
-        data2,
-        strict_type=strict_type,
-        numerical_precision=numerical_precision,
-        **kwargs
+        data1, data2, strict_type=strict_type, numerical_precision=numerical_precision, **kwargs
     )
     if not isinstance(evaluated, (bool, np.bool_)):
         # When either one of input is numpy array type, it may broadcast equality check
@@ -246,7 +237,7 @@ def _check_service_analysis_results(
     **kwargs,
 ):
     """Check equality of AnalysisResult class which is payload for experiment service."""
-    attrs=[
+    attrs = [
         "name",
         "value",
         "extra",

--- a/test/framework/test_framework.py
+++ b/test/framework/test_framework.py
@@ -120,13 +120,18 @@ class TestFramework(QiskitExperimentsTestCase):
     def test_run_analysis_experiment_data_pickle_roundtrip(self):
         """Test running analysis on ExperimentData after pickle roundtrip"""
         analysis = FakeAnalysis()
-        expdata1 = analysis.run(ExperimentData(), seed=54321)
+        expdata1 = ExperimentData()
+        # Set physical qubit for more complete comparison
+        expdata1.metadata["physical_qubits"] = (1,)
+        expdata1 = analysis.run(expdata1, seed=54321)
         self.assertExperimentDone(expdata1)
 
-        expdata2 = pickle.loads(pickle.dumps(expdata1))
+        expdata2 = ExperimentData(experiment_id=expdata1.experiment_id)
+        expdata2.metadata["physical_qubits"] = (1,)
+        expdata2 = pickle.loads(pickle.dumps(expdata2))
         expdata2 = analysis.run(expdata2, replace_results=True, seed=54321)
         self.assertExperimentDone(expdata2)
-        self.assertEqualExtended(expdata1, expdata2, ignore_result_id=True)
+        self.assertEqualExtended(expdata1, expdata2)
 
     def test_analysis_replace_results_true(self):
         """Test running analysis with replace_results=True"""

--- a/test/framework/test_framework.py
+++ b/test/framework/test_framework.py
@@ -12,6 +12,7 @@
 
 """Tests for base experiment framework."""
 
+import pickle
 from test.fake_experiment import FakeExperiment, FakeAnalysis
 from test.base import QiskitExperimentsTestCase
 from itertools import product
@@ -115,6 +116,17 @@ class TestFramework(QiskitExperimentsTestCase):
             if num_circuits % max_circuits:
                 num_jobs += 1
         self.assertEqual(len(job_ids), num_jobs)
+
+    def test_run_analysis_experiment_data_pickle_roundtrip(self):
+        """Test running analysis on ExperimentData after pickle roundtrip"""
+        analysis = FakeAnalysis()
+        expdata1 = analysis.run(ExperimentData(), seed=54321)
+        self.assertExperimentDone(expdata1)
+
+        expdata2 = pickle.loads(pickle.dumps(expdata1))
+        expdata2 = analysis.run(expdata2, replace_results=True, seed=54321)
+        self.assertExperimentDone(expdata2)
+        self.assertEqualExtended(expdata1, expdata2, ignore_result_id=True)
 
     def test_analysis_replace_results_true(self):
         """Test running analysis with replace_results=True"""


### PR DESCRIPTION
Previously, `ExperimentData` objects could be serialized and
deserialized using Python's `pickle` module, but deserialized objects
were not completely restored and an exception would be raised when doing
some operations like running analysis on the restored object.