### PR TITLE
Replace `qiskit-terra` dev requirement with `qiskit`

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-qiskit-terra>=0.45.0
+qiskit>=0.45.0
 black~=22.0
 fixtures
 stestr


### PR DESCRIPTION
### Summary

Now that the metapackage has been removed in https://github.com/Qiskit/qiskit/pull/11271, we should be able to run the daily cron jobs against `qiskit` and not `qiskit-terra`.