### PR TITLE
Remove workarounds for qiskit-aer 0.13.0

### DIFF
--- a/requirements-extras.txt
+++ b/requirements-extras.txt
@@ -1,5 +1,5 @@
 qiskit-ibm-provider>=0.6.1 # for submitting experiments to backends through the IBM provider
 cvxpy>=1.3.2 # for tomography
 scikit-learn # for discriminators
-qiskit-aer>=0.11.0,<=0.12.2 # temporary version pin until 0.13.1 release
+qiskit-aer>=0.11.0
 qiskit_dynamics>=0.4.0 # for the PulseBackend

--- a/test/library/tomography/tomo_utils.py
+++ b/test/library/tomography/tomo_utils.py
@@ -87,9 +87,7 @@ def readout_noise_model(num_qubits, seed=None):
     p1g0s = 0.15 * rng.random(num_qubits)
     p0g1s = 0.3 * rng.random(num_qubits)
     amats = np.stack([[1 - p1g0s, p1g0s], [p0g1s, 1 - p0g1s]]).T
-    # Set `basis_gates` so that reset is included.
-    # See https://github.com/Qiskit/qiskit-aer/issues/1975
-    noise_model = NoiseModel(basis_gates=["id", "rz", "sx", "cx", "reset"])
+    noise_model = NoiseModel()
     for i, amat in enumerate(amats):
         noise_model.add_readout_error(amat.T, [i])
     return noise_model


### PR DESCRIPTION
+ Unpin qiskit-aer extra requirement now that 0.13.1 has been released and we do not have to worry about https://github.com/Qiskit/qiskit-aer/issues/1985
+ Remove workaround in test for https://github.com/Qiskit/qiskit-aer/issues/1975

Note that the tests will not pass with 0.13.0 because the workaround was removed, but the workaround was for an Aer bug so we don't reflect it as an incomapitibility with qiskit-experiments.