### PR TITLE
Minor docs updates

### DIFF
--- a/docs/howtos/cloud_service.rst
+++ b/docs/howtos/cloud_service.rst
@@ -4,7 +4,7 @@ Save and load experiment data with the cloud service
 .. note::
     This guide is only for those who have access to the cloud service. You can 
     check whether you do by logging into the IBM Quantum interface 
-    and seeing if you can see the `database <https://quantum-computing.ibm.com/experiments>`__.
+    and seeing if you can see the `database <https://quantum.ibm.com/experiments>`__.
 
 Problem
 -------
@@ -44,13 +44,13 @@ backend and not a simulator to be able to save the experiment data. This is done
 .. jupyter-output::
 
     You can view the experiment online at 
-    https://quantum-computing.ibm.com/experiments/10a43cb0-7cb9-41db-ad74-18ea6cf63704
+    https://quantum.ibm.com/experiments/10a43cb0-7cb9-41db-ad74-18ea6cf63704
 
 Loading
 ~~~~~~~
 
 Let's load a `previous T1
-experiment <https://quantum-computing.ibm.com/experiments/9640736e-d797-4321-b063-d503f8e98571>`__ 
+experiment <https://quantum.ibm.com/experiments/9640736e-d797-4321-b063-d503f8e98571>`__ 
 (requires login to view), which we've made public by editing the ``Share level`` field:
 
 .. jupyter-input::
@@ -143,7 +143,7 @@ The :meth:`~.ExperimentData.auto_save` feature automatically saves changes to th
 
 .. jupyter-output::
 
-    You can view the experiment online at https://quantum-computing.ibm.com/experiments/cdaff3fa-f621-4915-a4d8-812d05d9a9ca
+    You can view the experiment online at https://quantum.ibm.com/experiments/cdaff3fa-f621-4915-a4d8-812d05d9a9ca
     <ExperimentData[T1], backend: ibmq_lima, status: ExperimentStatus.DONE, experiment_id: cdaff3fa-f621-4915-a4d8-812d05d9a9ca>
 
 Setting ``auto_save = True`` works by triggering :meth:`.ExperimentData.save`.
@@ -188,5 +188,5 @@ Web interface
 ~~~~~~~~~~~~~
 
 You can also view experiment results as well as change the tags and share level at the `IBM Quantum Experiments
-pane <https://quantum-computing.ibm.com/experiments?date_interval=last-90-days&owner=me>`__
+pane <https://quantum.ibm.com/experiments?date_interval=last-90-days&owner=me>`__
 on the cloud.

--- a/docs/howtos/experiment_times.rst
+++ b/docs/howtos/experiment_times.rst
@@ -24,7 +24,7 @@ are all of type ``datetime.datetime`` and in your local timezone:
 .. note::
     The below attributes are only relevant for those who have access to the cloud service. You can 
     check whether you do by logging into the IBM Quantum interface 
-    and seeing if you can see the `database <https://quantum-computing.ibm.com/experiments>`__.
+    and seeing if you can see the `database <https://quantum.ibm.com/experiments>`__.
 
 - :attr:`.ExperimentData.creation_datetime` is the time when the experiment data was saved via the
   service. This defaults to ``None`` if experiment data has not yet been saved.

--- a/docs/howtos/rerun_analysis.rst
+++ b/docs/howtos/rerun_analysis.rst
@@ -66,7 +66,7 @@ contain correct results.
 
 In the case where jobs are not directly accessible from the provider but you've
 downloaded the jobs from the 
-`IQS dashboard <https://quantum-computing.ibm.com/jobs>`_, you can load them from
+`IQS dashboard <https://quantum.ibm.com/jobs>`_, you can load them from
 the downloaded directory into :class:`~qiskit.result.Result` objects with this code:
 
 .. jupyter-input::

--- a/docs/howtos/runtime_sessions.rst
+++ b/docs/howtos/runtime_sessions.rst
@@ -5,7 +5,7 @@ Problem
 -------
 
 You want to run experiments in a `Runtime session
-<https://qiskit.org/ecosystem/ibm-runtime/sessions.html>`_ so that jobs can run in close temporal proximity.
+<https://docs.quantum.ibm.com/run/sessions>`_ so that jobs can run in close temporal proximity.
 
 Solution
 --------

--- a/docs/tutorials/calibrations.rst
+++ b/docs/tutorials/calibrations.rst
@@ -12,9 +12,8 @@ measurement data manually.
 In this tutorial, we demonstrate how to calibrate single-qubit gates using the
 calibration framework in Qiskit Experiments. We will run experiments on our test pulse
 backend, :class:`.SingleTransmonTestBackend`, a backend that simulates the underlying
-pulses with `Qiskit Dynamics <https://qiskit.org/documentation/dynamics/>`_ on a
-three-level model of a transmon. You can also run these experiments on any real backend
-with Pulse enabled (see
+pulses with :mod:`qiskit_dynamics` on a three-level model of a transmon. You can also
+run these experiments on any real backend with Pulse enabled (see
 :external+qiskit:doc:`tutorials/circuits_advanced/08_gathering_system_information`).
 
 We will run experiments to 

--- a/qiskit_experiments/calibration_management/calibrations.py
+++ b/qiskit_experiments/calibration_management/calibrations.py
@@ -1270,12 +1270,12 @@ class Calibrations:
         Returns:
             data: A list of dictionaries with all the schedules in it. The key-value pairs are
 
-                * 'qubits': the qubits to which this schedule applies. This may be an empty
-                  tuple () if the schedule is the default for all qubits.
-                * 'schedule': The schedule.
-                * 'parameters': The parameters in the schedule exposed for convenience.
+            * ``qubits``: the qubits to which this schedule applies. This may be an empty
+                tuple () if the schedule is the default for all qubits.
+            * ``schedule``: The schedule.
+            * ``parameters``: The parameters in the schedule exposed for convenience.
 
-                This list of dictionaries can easily be converted to a data frame.
+            This list of dictionaries can easily be converted to a data frame.
         """
         data = []
         for key, sched in self._schedules.items():

--- a/qiskit_experiments/framework/analysis_result_table.py
+++ b/qiskit_experiments/framework/analysis_result_table.py
@@ -85,13 +85,14 @@ class AnalysisResultTable(ThreadSafeContainer):
 
         Args:
             columns: Specifying a set of columns to return. You can pass a list of each
-                column name to return, otherwise builtin column groups are available.
+                column name to return, otherwise builtin column groups are available:
 
-                    * "all": Return all columns, including metadata to communicate
-                        with experiment service, such as entry IDs.
-                    * "default": Return columns including analysis result with supplementary
-                        information about experiment.
-                    * "minimal": Return only analysis subroutine returns.
+                * ``all``: Return all columns, including metadata to communicate
+                  with experiment service, such as entry IDs.
+                * ``default``: Return columns including analysis result with supplementary
+                  information about experiment.
+                * ``minimal``: Return only analysis subroutine returns.
+            
 
         Raises:
             ValueError: When column is given in string which doesn't match with any builtin group.

--- a/qiskit_experiments/framework/analysis_result_table.py
+++ b/qiskit_experiments/framework/analysis_result_table.py
@@ -92,7 +92,7 @@ class AnalysisResultTable(ThreadSafeContainer):
                 * ``default``: Return columns including analysis result with supplementary
                   information about experiment.
                 * ``minimal``: Return only analysis subroutine returns.
-            
+
 
         Raises:
             ValueError: When column is given in string which doesn't match with any builtin group.

--- a/qiskit_experiments/framework/experiment_data.py
+++ b/qiskit_experiments/framework/experiment_data.py
@@ -205,7 +205,7 @@ class ExperimentData:
     .. note::
         Saving experiment data to the cloud database is currently a limited access feature. You can
         check whether you have access by logging into the IBM Quantum interface
-        and seeing if you can see the `database <https://quantum-computing.ibm.com/experiments>`__.
+        and seeing if you can see the `database <https://quantum.ibm.com/experiments>`__.
 
     This class handles the following:
 
@@ -1541,9 +1541,9 @@ class ExperimentData:
                 column name to return, otherwise builtin column groups are available.
 
                     * "all": Return all columns, including metadata to communicate
-                        with experiment service, such as entry IDs.
+                    with the experiment service, such as entry IDs.
                     * "default": Return columns including analysis result with supplementary
-                        information about experiment.
+                    information about experiment.
                     * "minimal": Return only analysis subroutine returns.
 
             dataframe: Set True to return analysis results in the dataframe format.
@@ -1779,7 +1779,7 @@ class ExperimentData:
         if not self.service.local and self.verbose:
             print(
                 "You can view the experiment online at "
-                f"https://quantum-computing.ibm.com/experiments/{self.experiment_id}"
+                f"https://quantum.ibm.com/experiments/{self.experiment_id}"
             )
         # handle children, but without additional prints
         if save_children:
@@ -2523,7 +2523,7 @@ class ExperimentData:
     @staticmethod
     def get_service_from_provider(provider):
         """Initializes the service from the provider data"""
-        db_url = "https://auth.quantum-computing.ibm.com/api"
+        db_url = "https://auth.quantum.ibm.com/api"
         try:
             # qiskit-ibmq-provider style
             if hasattr(provider, "credentials"):

--- a/qiskit_experiments/framework/experiment_data.py
+++ b/qiskit_experiments/framework/experiment_data.py
@@ -1528,25 +1528,25 @@ class ExperimentData:
             index: Index of the analysis result to be returned.
                 Several types are accepted for convenience:
 
-                    * None: Return all analysis results.
-                    * int: Specific index of the analysis results.
-                    * slice: A list slice of indexes.
-                    * str: ID or name of the analysis result.
+                * None: Return all analysis results.
+                * int: Specific index of the analysis results.
+                * slice: A list slice of indexes.
+                * str: ID or name of the analysis result.
 
             refresh: Retrieve the latest analysis results from the server, if
                 an experiment service is available.
-            block: If True block for any analysis callbacks to finish running.
+            block: If ``True``, block for any analysis callbacks to finish running.
             timeout: max time in seconds to wait for analysis callbacks to finish running.
             columns: Specifying a set of columns to return. You can pass a list of each
-                column name to return, otherwise builtin column groups are available.
+                column name to return, otherwise builtin column groups are available:
 
-                    * "all": Return all columns, including metadata to communicate
-                    with the experiment service, such as entry IDs.
-                    * "default": Return columns including analysis result with supplementary
-                    information about experiment.
-                    * "minimal": Return only analysis subroutine returns.
+                * ``all``: Return all columns, including metadata to communicate
+                  with the experiment service, such as entry IDs.
+                * ``default``: Return columns including analysis result with supplementary
+                  information about experiment.
+                * ``minimal``: Return only analysis subroutine returns.
 
-            dataframe: Set True to return analysis results in the dataframe format.
+            dataframe: Set to ``True`` to return analysis results in the dataframe format.
 
         Returns:
             Analysis results for this experiment.

--- a/qiskit_experiments/library/calibration/fine_frequency_cal.py
+++ b/qiskit_experiments/library/calibration/fine_frequency_cal.py
@@ -123,7 +123,7 @@ class FineFrequencyCal(BaseCalibrationExperiment, FineFrequency):
 
         The frequency of the qubit is updated according to
 
-        ..math::
+        .. math::
 
             f \to f - \frac{{\rm d}\theta}{2\pi\tau{\rm d}t}
 

--- a/qiskit_experiments/library/calibration/half_angle_cal.py
+++ b/qiskit_experiments/library/calibration/half_angle_cal.py
@@ -130,7 +130,7 @@ class HalfAngleCal(BaseCalibrationExperiment, HalfAngle):
         in the complex amplitude of the pulse. The update rule for the half angle calibration is
         therefore:
 
-        ..math::
+        .. math::
 
             A \to A \cdot e^{-i{\rm d}\theta_\text{hac}/2}
 

--- a/qiskit_experiments/library/characterization/analysis/correlated_readout_error_analysis.py
+++ b/qiskit_experiments/library/characterization/analysis/correlated_readout_error_analysis.py
@@ -33,7 +33,7 @@ class CorrelatedReadoutErrorAnalysis(BaseAnalysis):
         :math:`A` is a :math:`2^n\times 2^n` matrix :math:`A` such that :math:`A_{y,x}`
         is the probability to observe :math:`y` given the true outcome should be :math:`x`.
 
-        In the experiment, for each :math:`x`a circuit is constructed whose expected
+        In the experiment, for each :math:`x` a circuit is constructed whose expected
         outcome is :math:`x`. From the observed results on the circuit, the probability for
         each :math:`y` is determined, and :math:`A_{y,x}` is set accordingly.
 

--- a/qiskit_experiments/library/characterization/rabi.py
+++ b/qiskit_experiments/library/characterization/rabi.py
@@ -187,7 +187,7 @@ class Rabi(BaseExperiment, RestlessMixin):
 
 class EFRabi(Rabi):
     r"""An experiment that scans the amplitude of a pulse inducing rotations on the
-        :math:`|1\rangle` <-> :math:`|2\rangle` transition.
+    :math:`|1\rangle` <-> :math:`|2\rangle` transition.
 
     # section: overview
 

--- a/qiskit_experiments/library/characterization/rabi.py
+++ b/qiskit_experiments/library/characterization/rabi.py
@@ -187,7 +187,7 @@ class Rabi(BaseExperiment, RestlessMixin):
 
 class EFRabi(Rabi):
     r"""An experiment that scans the amplitude of a pulse inducing rotations on the
-     :math:`|1\rangle` <-> :math:`|2\rangle` transition.
+        :math:`|1\rangle` <-> :math:`|2\rangle` transition.
 
     # section: overview
 

--- a/qiskit_experiments/library/tomography/basis/base_basis.py
+++ b/qiskit_experiments/library/tomography/basis/base_basis.py
@@ -100,7 +100,7 @@ class PreparationBasis(BaseBasis):
 
     @abstractmethod
     def matrix_shape(self, qubits: Sequence[int]) -> Tuple[int, ...]:
-        """Return the shape of subsystem dimensions of the state attr:`~matrix`.
+        """Return the shape of subsystem dimensions of the state :attr:`~matrix`.
 
         Args:
             qubits: the physical qubit subsystems.
@@ -170,7 +170,7 @@ class MeasurementBasis(BaseBasis):
 
     @abstractmethod
     def matrix_shape(self, qubits: Sequence[int]) -> Tuple[int, ...]:
-        """Return the shape of subsystem dimensions of a POVM attr:`~matrix`.
+        """Return the shape of subsystem dimensions of a POVM :attr:`~matrix`.
 
         Args:
             qubits: the physical qubit subsystems.

--- a/qiskit_experiments/test/mock_iq_backend.py
+++ b/qiskit_experiments/test/mock_iq_backend.py
@@ -229,7 +229,7 @@ class MockIQBackend(FakeOpenPulse2QV2):
 
         Args:
             experiment_helper(MockIQExperimentHelper): Experiment helper class that contains
-                'compute_probabilities' function and 'iq_phase' function for the backend to execute.
+                :meth:`.compute_probabilities` and :meth:`.iq_phase` methods for the backend to execute.
             rng_seed(int): The random seed value.
         """
 

--- a/qiskit_experiments/test/mock_iq_backend.py
+++ b/qiskit_experiments/test/mock_iq_backend.py
@@ -229,7 +229,8 @@ class MockIQBackend(FakeOpenPulse2QV2):
 
         Args:
             experiment_helper(MockIQExperimentHelper): Experiment helper class that contains
-                :meth:`.compute_probabilities` and :meth:`.iq_phase` methods for the backend to execute.
+                :meth:`~MockIQExperimentHelper.compute_probabilities` and 
+                :meth:`~MockIQExperimentHelper.iq_phase` methods for the backend to execute.
             rng_seed(int): The random seed value.
         """
 

--- a/qiskit_experiments/test/mock_iq_backend.py
+++ b/qiskit_experiments/test/mock_iq_backend.py
@@ -229,7 +229,7 @@ class MockIQBackend(FakeOpenPulse2QV2):
 
         Args:
             experiment_helper(MockIQExperimentHelper): Experiment helper class that contains
-                :meth:`~MockIQExperimentHelper.compute_probabilities` and 
+                :meth:`~MockIQExperimentHelper.compute_probabilities` and
                 :meth:`~MockIQExperimentHelper.iq_phase` methods for the backend to execute.
             rng_seed(int): The random seed value.
         """

--- a/qiskit_experiments/test/mock_iq_helpers.py
+++ b/qiskit_experiments/test/mock_iq_helpers.py
@@ -44,9 +44,9 @@ class MockIQExperimentHelper:
         :class:`MockIQBackend` instance. These are used by :meth:`iq_clusters` by
         default. Subclasses can override :meth:`iq_clusters` to return a modified
         version of :attr:`iq_cluster_centers` and :attr:`iq_cluster_width`.
-        `iq_cluster_centers` is a list of tuples. For a given qubit ``i_qbt`` and
+        :attr:`iq_cluster_centers` is a list of tuples. For a given qubit ``i_qbt`` and
         computational state ``i_state`` (either `0` or `1`), the centers of the IQ
-        clusters are found by indexing ``iq_cluster_centers`` as follows:
+        clusters are found by indexing :attr:`iq_cluster_centers` as follows:
 
         .. code-block:: python
 
@@ -69,7 +69,7 @@ class MockIQExperimentHelper:
                 are different centers for different logical values of the qubit. Defaults to a single
                 qubit with clusters in quadrants 1 and 3.
             iq_cluster_width: A list of standard deviation values for the sampling of each qubit.
-                Defaults to widths of 1.0 for each qubit in `iq_cluster_centers`.
+                Defaults to widths of 1.0 for each qubit in :attr:`iq_cluster_centers`.
 
         """
         self._iq_cluster_centers = (
@@ -192,15 +192,15 @@ class MockIQExperimentHelper:
         Subclasses can override this function to modify the centers and widths of IQ clusters based on
         the circuits being simulated by a :class:`MockIQBackend`. The base centers and widths are
         stored internally within the helper object, and can be set in :meth:`__init__` or by modifying
-        attr:`iq_cluster_centers` and attr:`iq_cluster_width`. The default behaviour for
+        :attr:`iq_cluster_centers` and :attr:`iq_cluster_width`. The default behavior for
         :meth:`iq_clusters` is to return the centers and widths unmodified for each circuit in
-        `circuits`. Subclasses may return different centers and widths based on the circuits provided.
+        ``circuits``. Subclasses may return different centers and widths based on the circuits provided.
 
         The returned list contains a tuple per circuit. Each tuple contains the IQ centers and widths in
-        the same format as attr:`iq_cluster_centers` and attr:`iq_cluster_width`, passed as
+        the same format as :attr:`iq_cluster_centers` and :attr:`iq_cluster_width`, passed as
         arguments to :meth:`__init__`. The format of the centers and widths lists, in the argument
-        list and in the returned tuples, must match the format of `iq_cluster_centers` and
-        `iq_cluster_width` in :func:`qiskit_experiments.test.MockIQExperimentHelper.__init__`.
+        list and in the returned tuples, must match the format of :attr:`iq_cluster_centers` and
+        :attr:`iq_cluster_width` in :func:`qiskit_experiments.test.MockIQExperimentHelper.__init__`.
 
         Args:
             circuits: The quantum circuits for which the clusters should be modified.
@@ -224,7 +224,7 @@ class MockIQParallelExperimentHelper(MockIQExperimentHelper):
         Parallel Experiment Helper initializer. The class assumes `exp_helper_list` is ordered to
         match the corresponding experiment in `exp_list`.
 
-        Note that :meth:`__init__` does not have `iq_cluster_centers` and `iq_cluster_width` as in
+        Note that :meth:`__init__` does not have :attr:`iq_cluster_centers` and :attr:`iq_cluster_width` as in
         :func:`MockIQExperimentHelper.__init__`. This is because the centers and widths for
         :class:`MockIQParallelBackend` are stored in multiple experiment helpers in the list
         `exp_helper_list`.

--- a/qiskit_experiments/test/mock_iq_helpers.py
+++ b/qiskit_experiments/test/mock_iq_helpers.py
@@ -224,8 +224,8 @@ class MockIQParallelExperimentHelper(MockIQExperimentHelper):
         Parallel Experiment Helper initializer. The class assumes `exp_helper_list` is ordered to
         match the corresponding experiment in `exp_list`.
 
-        Note that :meth:`__init__` does not have :attr:`iq_cluster_centers` and :attr:`iq_cluster_width` as in
-        :func:`MockIQExperimentHelper.__init__`. This is because the centers and widths for
+        Note that :meth:`__init__` does not have :attr:`iq_cluster_centers` and :attr:`iq_cluster_width`
+        as in :func:`MockIQExperimentHelper.__init__`. This is because the centers and widths for
         :class:`MockIQParallelBackend` are stored in multiple experiment helpers in the list
         `exp_helper_list`.
 

--- a/qiskit_experiments/test/pulse_backend.py
+++ b/qiskit_experiments/test/pulse_backend.py
@@ -452,7 +452,7 @@ class SingleTransmonTestBackend(PulseBackend):
         H = \hbar \sum_{j=1,2} \left[\omega_j |j\rangle\langle j| +
                 \mathcal{E}(t) \lambda_j (\sigma_j^+ + \sigma_j^-)\right]
 
-    Here, :math:`\omega_j` is the transition frequency from level :math`0` to level
+    Here, :math:`\omega_j` is the transition frequency from level :math:`0` to level
     :math:`j`. :math:`\mathcal{E}(t)` is the drive field and :math:`\sigma_j^\pm` are
     the raising and lowering operators between levels :math:`j-1` and :math:`j`.
     """

--- a/releasenotes/notes/setter-methods-for-experiment-099074e59faffb49.yaml
+++ b/releasenotes/notes/setter-methods-for-experiment-099074e59faffb49.yaml
@@ -4,5 +4,5 @@ features:
     Added ``experiment_type`` as optional ``__init__`` kwarg in :class:`.BatchExperiment`
     and :class:`.ParallelExperiment`.
   - |
-    :math:'experiment_type' can now be easily set and retrieved from the experiment
-    object post-construction using the 'experiment_type' property and setter.
+    ``experiment_type`` can now be easily set and retrieved from the experiment
+    object post-construction using the ``experiment_type`` property and setter.


### PR DESCRIPTION
- Update `quantum-computing.ibm.com` links to `quantum.ibm.com`
- Fix bad indents and stylings in docstrings
- Replace hard links with intersphinx/new Qiskit docs URL