### PR TITLE
Fix guess.rb_decay not to raise an error against bad output

### DIFF
--- a/qiskit_experiments/curve_analysis/guess.py
+++ b/qiskit_experiments/curve_analysis/guess.py
@@ -398,7 +398,9 @@ def rb_decay(
     y = y[valid_inds]
     x = x[valid_inds]
 
-    if len(x) < 2:
+    if len(x) == 0:
+        return 0
+    if len(x) == 1:
         # If number of element is 1, assume y(0) = 1.0 and directly compute alpha.
         a = 1.0 - b
         return ((y[0] - b) / a) ** (1 / x[0])

--- a/releasenotes/notes/fix-guess-rb-decay-f78e40a7d6d8dd67.yaml
+++ b/releasenotes/notes/fix-guess-rb-decay-f78e40a7d6d8dd67.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed a bug in :func:`~.rb_decay` where it unintentionally raises
+    an ``IndexError`` if all ``y`` values are below ``b`` value
+    so that it returns ``0`` for the case.

--- a/test/curve_analysis/test_guess.py
+++ b/test/curve_analysis/test_guess.py
@@ -207,3 +207,9 @@ class TestGuesses(QiskitExperimentsTestCase):
         alpha_guess = guess.rb_decay(x, y, b=b)
 
         self.assertAlmostEqual(alpha, alpha_guess, delta=alpha * 0.1)
+
+    def test_rb_decay_with_very_bad_output(self):
+        """Test if rb decay guess does not raise an error even for very bad outputs."""
+        x = np.array([1, 2, 3])
+        y = np.array([0.24, 0.22, 0.23])  # all are below b
+        guess.rb_decay(x=x, y=y, b=0.25)

--- a/test/curve_analysis/test_guess.py
+++ b/test/curve_analysis/test_guess.py
@@ -212,4 +212,5 @@ class TestGuesses(QiskitExperimentsTestCase):
         """Test if rb decay guess does not raise an error even for very bad outputs."""
         x = np.array([1, 2, 3])
         y = np.array([0.24, 0.22, 0.23])  # all are below b
-        guess.rb_decay(x=x, y=y, b=0.25)
+        out = guess.rb_decay(x=x, y=y, b=0.25)
+        self.assertEqual(out, 0.0)


### PR DESCRIPTION
### Summary
Fixed a bug in `guess.rb_decay` where it unintentionally raises an error if all y values are below the b value (that can happen in experiments on real devices).

### Details and comments
Changed to return `0` as the initial guess of the decay parameter when all y values are below the b value, instead of raising an IndexError like
```
File "/qiskit-experiments/qiskit_experiments/curve_analysis/guess.py", line 406, in rb_decay
    return ((y[0] - b) / a) ** (1 / x[0])
IndexError: index 0 is out of bounds for axis 0 with size 0
```

An alternative solution might be explicitly raising a QiskitError. But, if we want to raise an error for too bad data to fit, I think the fitter (not rb_decay) should raise an error because it should not be due to the failure of guessing initial parameter (that is the object of `rb_decay` function.