### PR TITLE
[WIP] Forcing experiment configuration for restless experiments.

### DIFF
--- a/qiskit_experiments/framework/base_experiment.py
+++ b/qiskit_experiments/framework/base_experiment.py
@@ -451,7 +451,7 @@ class BaseExperiment(ABC, StoreInitArgs):
     @classmethod
     def _default_run_options(cls) -> Options:
         """Default options values for the experiment :meth:`run` method."""
-        return Options(meas_level=MeasLevel.CLASSIFIED)
+        return Options(meas_level=MeasLevel.CLASSIFIED, restless=False)
 
     @property
     def run_options(self) -> Options:

--- a/qiskit_experiments/library/characterization/rabi.py
+++ b/qiskit_experiments/library/characterization/rabi.py
@@ -27,7 +27,7 @@ from qiskit_experiments.framework.restless_mixin import RestlessMixin
 from qiskit_experiments.curve_analysis import ParameterRepr, OscillationAnalysis
 
 
-class Rabi(BaseExperiment, RestlessMixin):
+class Rabi(RestlessMixin, BaseExperiment):
     r"""An experiment that scans a pulse amplitude to calibrate rotations on the :math:`|0\rangle`
     <-> :math:`|1\rangle` transition.
 


### PR DESCRIPTION
### Summary
Force configuration of restless on an experiment as described in #795 .
Please describe what this PR changes as concisely as possible. Link to the issue(s) that this addresses, if any.

### Details and comments

Some details that should be in this section include:

- This change is necessary so restless experiment would run without errors due to run options that contradict restless experiment
- An alternative solution was to make a restless experiment class. It was discarded because I wanted to change the code as less as possible.
- What tests and documentation have been added/updated
- If an experiment can be executed with `restless` configuration, Inheritance of `RestlessMixin` class should be first for correct method resolution order.  

### PR checklist (delete when all criteria are met)

- [x] I have read the contributing guide `CONTRIBUTING.md`.
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a release note file using `reno` if this change needs to be documented in the release notes.
