### PR TITLE
Fix rerun analysis how-to

### DIFF
--- a/docs/howtos/rerun_analysis.rst
+++ b/docs/howtos/rerun_analysis.rst
@@ -37,12 +37,14 @@ job IDs:
 
     expdata = ExperimentData(experiment = experiment)
     expdata.add_jobs([provider.retrieve_job(job_id) for job_id in job_ids])
-    experiment.analysis.run(expdata)
+    experiment.analysis.run(expdata, replace_results=True)
 
     # Block execution of subsequent code until analysis is complete
     expdata.block_for_results()
 
-``expdata`` will be the new experiment data object containing results of the rerun analysis.
+``expdata`` will be the new experiment data object containing results of the rerun analysis. Note that if
+``replace_results`` isn't set, running the analysis will return a new :class:`.ExperimentData` object
+instead of overwriting the existing one.
 
 If you have the job data in the form of a :class:`~qiskit.result.Result` object, you can
 invoke the :meth:`.add_data` method instead of :meth:`.add_jobs`:

--- a/docs/howtos/rerun_analysis.rst
+++ b/docs/howtos/rerun_analysis.rst
@@ -117,7 +117,7 @@ first component experiment.
 
     data = ExperimentData(experiment=pexp)
     data.add_jobs([provider.retrieve_job(job_id) for job_id in job_ids])
-    pexp.analysis.run(data)
+    pexp.analysis.run(data, replace_results=True)
 
 See Also
 --------


### PR DESCRIPTION
The rerun analysis how-to has been updated with the correct syntax for running the analysis so that the current experiment data object is overwritten instead of creating a new one. Closes #1185.