### PR TITLE
Turn off CI for forks

### DIFF
--- a/.github/workflows/cron-staging.yml
+++ b/.github/workflows/cron-staging.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   qiskit-main-tests:
+    if: github.repository_owner == 'Qiskit-Extensions'
     name: tests-python${{ matrix.python-version }}-${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -46,6 +47,7 @@ jobs:
           TEST_TIMEOUT: 120
           OMP_NUM_THREADS: 1
   docs:
+    if: github.repository_owner == 'Qiskit-Extensions'
     name: docs
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   deploy:
+    if: github.repository_owner == 'Qiskit-Extensions'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/docs_dev.yml
+++ b/.github/workflows/docs_dev.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   deploy:
+    if: github.repository_owner == 'Qiskit-Extensions'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   tests:
+    if: github.repository_owner == 'Qiskit-Extensions'
     name: tests-python${{ matrix.python-version }}-${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -62,6 +63,7 @@ jobs:
         run: stestr history remove all
 
   lint:
+    if: github.repository_owner == 'Qiskit-Extensions'
     name: lint
     runs-on: ubuntu-latest
     steps:
@@ -80,6 +82,7 @@ jobs:
       - name: Run lint
         run: tox -elint
   docs:
+    if: github.repository_owner == 'Qiskit-Extensions'
     name: docs
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/neko.yml
+++ b/.github/workflows/neko.yml
@@ -8,6 +8,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   neko:
+    if: github.repository_owner == 'Qiskit-Extensions'
     name: Qiskit Neko Integration Tests
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Follows https://github.com/Qiskit/qiskit/pull/10078. I don't see a reason to run CI on forks by default.