### PR TITLE
Reduce default parallelism of tox test runs

### DIFF
--- a/.github/workflows/cron-staging.yml
+++ b/.github/workflows/cron-staging.yml
@@ -45,7 +45,6 @@ jobs:
         if: runner.os == 'macOS'
         env:
           TEST_TIMEOUT: 120
-          OMP_NUM_THREADS: 1
   docs:
     if: github.repository_owner == 'Qiskit-Extensions'
     name: docs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,7 +58,6 @@ jobs:
         if: runner.os == 'macOS'
         env:
           TEST_TIMEOUT: 120
-          OMP_NUM_THREADS: 1
       - name: Clean up stestr cache
         run: stestr history remove all
 

--- a/tox.ini
+++ b/tox.ini
@@ -10,13 +10,13 @@ setenv =
   VIRTUAL_ENV={envdir}
   QISKIT_SUPPRESS_PACKAGING_WARNINGS=Y
   QISKIT_TEST_CAPTURE_STREAMS=1
+  OMP_NUM_THREADS={env:OMP_NUM_THREADS:1}
+  QISKIT_PARALLEL={env:QISKIT_PARALLEL:FALSE}
+  RAYON_NUM_THREADS={env:RAYON_NUM_THREADS:1}
 deps =
   -r{toxinidir}/requirements-dev.txt
   -r{toxinidir}/requirements-extras.txt
 passenv =
-  OMP_NUM_THREADS
-  QISKIT_PARALLEL
-  RAYON_NUM_THREADS
   QISKIT_IBM_*
   TEST_TIMEOUT
   QE_USE_TESTTOOLS
@@ -35,21 +35,10 @@ commands =
 [testenv:qiskit-main]
 usedevelop = True
 install_command = pip install -U {opts} {packages}
-setenv =
-  VIRTUAL_ENV={envdir}
-  QISKIT_SUPPRESS_PACKAGING_WARNINGS=Y
-  QISKIT_TEST_CAPTURE_STREAMS=1
 deps =
   git+https://github.com/Qiskit/qiskit
   -r{toxinidir}/requirements-dev.txt
   -r{toxinidir}/requirements-extras.txt
-passenv =
-  OMP_NUM_THREADS
-  QISKIT_PARALLEL
-  RAYON_NUM_THREADS
-  QISKIT_IBM_*
-  TEST_TIMEOUT
-  QE_USE_TESTTOOLS
 commands = stestr run {posargs}
 
 


### PR DESCRIPTION
Measurements of the total test time for different parallelism settings showed that total test time increased when `QISKIT_PARALLEL` was set to `TRUE` or `OMP_NUM_THREADS` was set higher than 1 when the `stestr` concurrency was higher than the number of physical cores. Additionally, no improvement was seen when increasing the `stestr` concurrency beyond the number of physical cores (for example up to two times that number on a system with 2x multithreading), but also no degradation in performance was observed, so the `stestr` concurrency was left at the default value (the number of logical CPUs rather than the number of physical CPUs) for simplicity.