### PR TITLE
Fix broken docs links

### DIFF
--- a/docs/howtos/figure_generation.rst
+++ b/docs/howtos/figure_generation.rst
@@ -42,4 +42,4 @@ overhead.
 See Also
 --------
 
-* The `Visualization tutorial <visualization.html>`_ discusses how to customize figures
+* The :doc:`Visualization tutorial </tutorials/visualization>` discusses how to customize figures

--- a/docs/tutorials/calibrations.rst
+++ b/docs/tutorials/calibrations.rst
@@ -14,7 +14,7 @@ calibration framework in Qiskit Experiments. We will run experiments on our test
 backend, :class:`.SingleTransmonTestBackend`, a backend that simulates the underlying
 pulses with :mod:`qiskit_dynamics` on a three-level model of a transmon. You can also
 run these experiments on any real backend with Pulse enabled (see
-:external+qiskit:doc:`tutorials/circuits_advanced/08_gathering_system_information`).
+:class:`qiskit.providers.models.BackendConfiguration`).
 
 We will run experiments to 
 find the qubit frequency, calibrate the amplitude of DRAG pulses, and choose the value 

--- a/docs/tutorials/getting_started.rst
+++ b/docs/tutorials/getting_started.rst
@@ -6,7 +6,7 @@ Installation
 ============
 
 Qiskit Experiments is built on top of Qiskit, so we recommend that you first install
-Qiskit following its :external+qiskit:doc:`installation guide <getting_started>`. Qiskit
+Qiskit following its `installation guide <https://docs.quantum.ibm.com/start/install>`__. Qiskit
 Experiments supports the same platforms as Qiskit itself and Python versions 3.8,
 3.9, 3.10, and 3.11.
 

--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -1,8 +1,8 @@
 Tutorials
 =========
 
-These tutorials assume some familiarity with Qiskit (on the level of the 
-:external+qiskit:doc:`introductory tutorials <tutorials>`) but no knowledge of Qiskit Experiments.
+These tutorials assume some familiarity with Qiskit (on the level of 
+`IBM Quantum Documentation's introductory guides <https://docs.quantum.ibm.com>`__) but no knowledge of Qiskit Experiments.
 They're suitable for beginners who want to get started with the package.
 
 .. _basics:


### PR DESCRIPTION
Qiskit 0.45.2 removed all tutorials, so intersphinx linking no longer works and breaks the docs build. This PR updates Qiskit tutorial links to 1XP pages that give the corresponding information and also fixes a broken internal link.