### PR TITLE
Fix Clifford synthesis not to use the old PassManager API

### DIFF
--- a/qiskit_experiments/library/randomized_benchmarking/clifford_synthesis.py
+++ b/qiskit_experiments/library/randomized_benchmarking/clifford_synthesis.py
@@ -19,6 +19,7 @@ from typing import Sequence
 from qiskit.circuit import QuantumCircuit, Operation
 from qiskit.circuit.equivalence_library import SessionEquivalenceLibrary as sel
 from qiskit.exceptions import QiskitError
+from qiskit.passmanager.flow_controllers import ConditionalController
 from qiskit.synthesis.clifford import synth_clifford_full
 from qiskit.transpiler import PassManager, CouplingMap, Layout, Target
 from qiskit.transpiler.passes import (
@@ -30,11 +31,6 @@ from qiskit.transpiler.passes import (
     Optimize1qGatesDecomposition,
 )
 from qiskit.transpiler.passes.synthesis.plugin import HighLevelSynthesisPlugin
-try:
-    # for qiskit>=1.0
-    from qiskit.passmanager.flow_controllers import ConditionalController
-except ImportError:
-    pass
 
 
 class RBDefaultCliffordSynthesis(HighLevelSynthesisPlugin):
@@ -99,14 +95,8 @@ class RBDefaultCliffordSynthesis(HighLevelSynthesisPlugin):
                 undo_layout_change,
                 BasisTranslator(sel, basis_gates),
                 CheckGateDirection(coupling_map),
+                ConditionalController(GateDirection(coupling_map), condition=_direction_condition),
+                Optimize1qGatesDecomposition(basis=basis_gates),
             ]
         )
-        try:
-            # for qiskit>=1.0
-            pm.append(ConditionalController(GateDirection(coupling_map), condition=_direction_condition))
-            pm.append(Optimize1qGatesDecomposition(basis=basis_gates))
-        except TypeError:
-            # for qiskit<1.0
-            pm.append([GateDirection(coupling_map)], condition=_direction_condition)
-            pm.append([Optimize1qGatesDecomposition(basis=basis_gates)])
         return pm.run(circ)


### PR DESCRIPTION
### Summary
Change to use the new PassManager API to make Clifford synthesis for 3Q+ RB work with qiskit 1.0.

### Details and comments
The old interface of `PassManager.append` has been removed since qiskit 1.0. It's been used to transpile 3Q+ RB circuits. This PR changes to use the new interface that uses `ConditionalController`.