### PR TITLE
Temporarily pin pandas to <2.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ matplotlib>=3.4
 uncertainties
 lmfit
 rustworkx
-pandas>=1.1.5
+pandas>=1.1.5,<2.2.0


### PR DESCRIPTION
2.2 deprecates APIs currently used by ScatterTable. This is a temporary pin to get CI working again until ScatterTable can be updated.