### PR TITLE
Remove qiskit-terra and qiskit-ibm-provider when testing against qiskit main

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -35,10 +35,13 @@ commands =
 [testenv:qiskit-main]
 usedevelop = True
 install_command = pip install -U {opts} {packages}
-deps =
-  git+https://github.com/Qiskit/qiskit
-  -r{toxinidir}/requirements-dev.txt
-  -r{toxinidir}/requirements-extras.txt
+commands_pre =
+  # We must remove qiskit-terra because some dependencies pull it in and it
+  # conflicts with qiskit main. We must remove qiskit-ibm-provider because it gives
+  # an import error for qiskit main and it gets automatically imported by qiskit's
+  # plugin mechanism.
+  pip uninstall -y qiskit qiskit-terra qiskit-ibm-provider
+  pip install git+https://github.com/Qiskit/qiskit
 commands = stestr run {posargs}
 
 
@@ -102,10 +105,10 @@ passenv =
   PROD_BUILD
   RELEASE_STRING
   VERSION_STRING
-deps =
-  git+https://github.com/Qiskit/qiskit
-  -r{toxinidir}/requirements-dev.txt
-  -r{toxinidir}/requirements-extras.txt
+commands_pre =
+  # See comment for qiskit-main
+  pip uninstall -y qiskit qiskit-terra qiskit-ibm-provider
+  pip install git+https://github.com/Qiskit/qiskit
 commands =
   sphinx-build -j auto -T -W --keep-going -b html {posargs} docs/ docs/_build/html
 


### PR DESCRIPTION
Other packages that depend on qiskit<1.0 will pull in qiskit and qiskit-terra together and qiskit-terra will conflict with qiskit main, so we remove it before installing qiskit main.

qiskit-ibm-provider 0.8.0 (current stable) tries to import `qiskit.extensions` for a basic `import qiskit_ibm_provider` which does not exist in qiskit main any more. qiskit-ibm-provider registers a qiskit plugin which causes it to get automatically imported under some conditions, triggering a warning in jupyter execute blocks which then cause a strict sphinx build to fail.