### PR TITLE
Add dependabot to upgrade GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+# Check for updates to GitHub Actions
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
I noticed some of our GitHub Actions, like checkout@v3, are outdated. Dependabot should be able to check these automatically and create pull requests. I didn't add `requirements.txt` to Dependabot since we don't have that many dependencies and we usually only bump the minimum version if needed.