### PR TITLE
Update old links in documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing Guide
 
 To contribute to Qiskit Experiments, first read the overall [Qiskit project contributing
-guidelines](https://qiskit.org/documentation/contributing_to_qiskit.html). In addition
+guidelines](https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md). In addition
 to the general guidelines, the specific guidelines for contributing to Qiskit
 Experiments are documented below.
 
@@ -13,6 +13,7 @@ Contents:
     - [Pull request checklist](#pull-request-checklist)
     - [Testing your code](#testing-your-code)
       - [STDOUT/STDERR and logging capture](#stdoutstderr-and-logging-capture)
+      - [Other testing related settings](#other-testing-related-settings)
     - [Code style](#code-style)
     - [Changelog generation](#changelog-generation)
     - [Release notes](#release-notes)
@@ -317,7 +318,7 @@ https://github.com/Qiskit-Extensions/qiskit-experiments/blob/main/docs/release_n
 
 ### Documentation
 
-The [Qiskit Experiments documentation](https://qiskit.org/ecosystem/experiments/) is
+The [Qiskit Experiments documentation](https://qiskit-extensions.github.io/qiskit-experiments) is
 rendered from `.rst` files as well as experiment and analysis class docstrings into HTML
 files.
 
@@ -325,7 +326,7 @@ files.
 
 Any change that would affect existing documentation, or a new feature that requires a
 documentation, should be updated correspondingly. Before updating, review the [existing
-documentation](https://qiskit.org/ecosystem/experiments) for their style and
+documentation](https://qiskit-extensions.github.io/qiskit-experiments) for their style and
 content, and read the [documentation guidelines](docs/GUIDELINES.md) for further
 details.
 
@@ -361,7 +362,7 @@ There are a few other build options available:
 ### Deprecation policy
 
 Qiskit Experiments is part of Qiskit and, therefore, the [Qiskit Deprecation
-Policy](https://qiskit.org/documentation/deprecation_policy.html) fully applies here.
+Policy](https://github.com/Qiskit/qiskit/blob/main/DEPRECATION.md) fully applies here.
 Public-facing changes must come with a deprecation warning for at least three months or
 two version cycles before the old feature is removed. Deprecations can only happen on
 minor releases and not on patch releases.
@@ -369,7 +370,7 @@ minor releases and not on patch releases.
 #### Adding deprecation warnings
 
 We use the deprecation wrappers in [Qiskit
-Utilities](https://qiskit.org/documentation/apidoc/utils.html) to add warnings:
+Utilities](https://docs.quantum.ibm.com/api/qiskit/utils) to add warnings:
 
 ```python
 

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@
 and analyzing experiments on noisy quantum computers using Qiskit.
 
 To learn more about the package, you can see the 
-[most up-to-date documentation](https://qiskit.org/ecosystem/experiments/dev/)
+[most up-to-date documentation](https://qiskit-extensions.github.io/qiskit-experiments/dev)
 corresponding to the main branch of this repository or the 
-[documentation for the latest stable release](https://qiskit.org/ecosystem/experiments).
+[documentation for the latest stable release](https://qiskit-extensions.github.io/qiskit-experiments).
 
 ## Contribution Guidelines
 

--- a/docs/GUIDELINES.md
+++ b/docs/GUIDELINES.md
@@ -162,8 +162,8 @@ example and example outputs by printing relevant analysis results and plot figur
 Required and common parameters, such as experiment and analysis options, should be
 covered.
 
-See the [Randomized Benchmarking](https://qiskit-extensions.github.io/qiskit-experiment/manuals/benchmarking/randomized_benchmarking.html)
-guide and its [source code](docs/manuals/benchmarking/randomized_benchmarking.rst) for an
+See the [Randomized Benchmarking](https://qiskit-extensions.github.io/qiskit-experiments/manuals/verification/randomized_benchmarking.html)
+guide and its [source code](manuals/verification/randomized_benchmarking.rst) for an
 example. Here is a simple template for a manual:
 
 ```
@@ -380,9 +380,9 @@ header should be named `Analysis Options` to be parsed correctly.
 After you complete documentation of your classes, you must add documentation to the
 toctree so that it can be rendered as the API documentation. In Qiskit Experiments, we
 have a separate tables of contents for each experiment module (e.g. [characterization
-experiments](https://qiskit-extensions.github.io/qiskit-experiment/apidocs/mod_characterization.html))
+experiments](https://qiskit-extensions.github.io/qiskit-experiments/apidocs/mod_characterization.html))
 and for the [entire
-library](https://qiskit-extensions.github.io/qiskit-experiment/apidocs/library.html). Thus we
+library](https://qiskit-extensions.github.io/qiskit-experiments/apidocs/library.html). Thus we
 should add document to the tree of a particular module and then reference it to the
 entire module.
 

--- a/docs/GUIDELINES.md
+++ b/docs/GUIDELINES.md
@@ -162,7 +162,7 @@ example and example outputs by printing relevant analysis results and plot figur
 Required and common parameters, such as experiment and analysis options, should be
 covered.
 
-See the [Randomized Benchmarking](https://qiskit.org/ecosystem/experiments/manuals/benchmarking/randomized_benchmarking.html)
+See the [Randomized Benchmarking](https://qiskit-extensions.github.io/qiskit-experiment/manuals/benchmarking/randomized_benchmarking.html)
 guide and its [source code](docs/manuals/benchmarking/randomized_benchmarking.rst) for an
 example. Here is a simple template for a manual:
 
@@ -380,9 +380,9 @@ header should be named `Analysis Options` to be parsed correctly.
 After you complete documentation of your classes, you must add documentation to the
 toctree so that it can be rendered as the API documentation. In Qiskit Experiments, we
 have a separate tables of contents for each experiment module (e.g. [characterization
-experiments](https://qiskit.org/ecosystem/experiments/apidocs/mod_characterization.html))
+experiments](https://qiskit-extensions.github.io/qiskit-experiment/apidocs/mod_characterization.html))
 and for the [entire
-library](https://qiskit.org/ecosystem/experiments/apidocs/library.html). Thus we
+library](https://qiskit-extensions.github.io/qiskit-experiment/apidocs/library.html). Thus we
 should add document to the tree of a particular module and then reference it to the
 entire module.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -169,12 +169,12 @@ html_last_updated_fmt = "%Y/%m/%d"
 autoclass_content = "both"
 intersphinx_mapping = {
     "matplotlib": ("https://matplotlib.org/stable/", None),
-    "qiskit": ("https://qiskit.org/documentation/", None),
+    "qiskit": ("https://docs.quantum.ibm.com/api/qiskit/", None),
     "uncertainties": ("https://pythonhosted.org/uncertainties", None),
     "qiskit_ibm_provider": ("https://qiskit.org/ecosystem/ibm-provider/", None),
     "qiskit_aer": ("https://qiskit.org/ecosystem/aer", None),
-    "qiskit_dynamics": ("https://qiskit.org/documentation/dynamics", None),
-    "qiskit_ibm_runtime": ("https://qiskit.org/ecosystem/ibm-runtime/", None),
+    "qiskit_dynamics": ("https://qiskit.org/ecosystem/dynamics/", None),
+    "qiskit_ibm_runtime": ("https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/", None),
 }
 
 

--- a/docs/howtos/job_splitting.rst
+++ b/docs/howtos/job_splitting.rst
@@ -38,9 +38,9 @@ Discussion
 ----------
 
 Qiskit Experiments will automatically split circuits across jobs for you for backends
-that have a maximum circuit number per circuit, which is given by the ``max_experiments`` 
-property of :meth:`qiskit.providers.BackendV1.configuration` for V1 backends and 
-:attr:`qiskit.providers.BackendV2.max_circuits` for V2. This should
+that have a maximum circuit number per job, which is given by the ``max_experiments`` 
+property of :meth:`~qiskit.providers.BackendV1.configuration` for V1 backends and 
+the :attr:`~qiskit.providers.BackendV2.max_circuits` attribute for V2 backends. This should
 work automatically in most cases, but there may be some backends where other limits
 exist. When the ``max_circuits`` experiment option is provided, the experiment class
 will split the experiment circuits as dictated by the smaller of the backend property

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -103,7 +103,7 @@ We've divided up the documentation into four sections with different purposes:
     apidocs/index
     release_notes
     GitHub <https://github.com/Qiskit-Extensions/qiskit-experiments>
-    Development Branch Docs <https://qiskit.org/ecosystem/experiments/dev>
+    Development Branch Docs <https://qiskit-extensions.github.io/qiskit-experiments/dev/>
 
 |
 

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     long_description_content_type="text/markdown",
     url="https://github.com/Qiskit-Extensions/qiskit-experiments",
     author="Qiskit Development Team",
-    author_email="hello@qiskit.org",
+    author_email="qiskit@us.ibm.com",
     license="Apache 2.0",
     classifiers=[
         "Environment :: Console",
@@ -66,7 +66,7 @@ setup(
     python_requires=">=3.8",
     project_urls={
         "Bug Tracker": "https://github.com/Qiskit-Extensions/qiskit-experiments/issues",
-        "Documentation": "https://qiskit.org/ecosystem/experiments",
+        "Documentation": "https://qiskit-extensions.github.io/qiskit-experiments",
         "Source Code": "https://github.com/Qiskit-Extensions/qiskit-experiments",
     },
     zip_safe=False,


### PR DESCRIPTION
Now that the docs have moved to https://qiskit-extensions.github.io/qiskit-experiments/, this PR updates links that were changed in the 1XP move.