### PR TITLE
Remove version pins on documentation dependencies

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,25 +1,26 @@
+# Linters
 black~=22.0
+pylint~=3.0.2
+astroid~=3.0.1  # Must be kept aligned to what pylint wants
+
+# Test runner tools
+coverage>=5.5
+ddt>=1.6.0
 fixtures
 stestr
 testtools
-pylint~=3.0.2
-astroid~=3.0.1  # Must be kept aligned to what pylint wants
-jinja2==3.0.3
-sphinx>=6.2.1,<=7
-jupyter-sphinx>=0.4.0
-qiskit-sphinx-theme~=1.14.0rc1
-sphinx-design~=0.4.1
-pygments>=2.4
-reno>=4.0.0
-nbsphinx
-arxiv
-ddt>=1.6.0
-pylatexenc
+
+# Extra dependencies for tests/documentation code
 multimethod
+
+# Documentation tools
+arxiv
+jupyter-sphinx>=0.4.0
+nbsphinx
+pylatexenc
+qiskit-sphinx-theme
+reno>=4.0.0
+sphinx>=6.2.1
 sphinx-copybutton
-coverage>=5.5
-# Pin versions below because of build errors
-ipykernel<=6.21.3
-jupyter-client<=8.0.3
-ipython<8.13.0 ; python_version<"3.9"  # for python 3.8 compatibility
+sphinx-design
 sphinx-remove-toctrees


### PR DESCRIPTION
Some of the pinned versions have gotten old and are confusing pip's resolver as it tries to find versions of the unpinned dependencies which are compatible with the pinned dependencies. The issues that led to the versions being pinned should be resolved.