### PR TITLE
Fix sphinx import in docs extension

### DIFF
--- a/docs/_ext/custom_styles/option_parser.py
+++ b/docs/_ext/custom_styles/option_parser.py
@@ -21,7 +21,8 @@ from typing import Any, Set, List, Tuple
 from typing import Type, Optional
 
 import numpy as np
-from sphinx.ext.autodoc import Sphinx, Options as SphinxOptions
+from sphinx.application import Sphinx
+from sphinx.ext.autodoc import Options as SphinxOptions
 from sphinx.ext.napoleon import Config as NapoleonConfig
 from sphinx.ext.napoleon import GoogleDocstring
 


### PR DESCRIPTION
The qiskit-experiments Sphinx extension was importing Sphinx from an internal location that was removed in 7.2. Here the import is moved to the main locaiont for the Sphinx app.