### PR TITLE
Remove remaining code usage deprecated in Qiskit 0.46

### DIFF
--- a/docs/manuals/measurement/readout_mitigation.rst
+++ b/docs/manuals/measurement/readout_mitigation.rst
@@ -40,7 +40,7 @@ experiments to generate the corresponding mitigators.
     import numpy as np
     import matplotlib.pyplot as plt
     from qiskit import QuantumCircuit
-    from qiskit.visualization import plot_histogram
+    from qiskit.visualization import plot_distribution
     from qiskit_experiments.library import LocalReadoutError, CorrelatedReadoutError
 
     from qiskit_aer import AerSimulator
@@ -128,7 +128,7 @@ Probabilities
 .. jupyter-execute::
 
     legend = ['Mitigated Probabilities', 'Unmitigated Probabilities']
-    plot_histogram([mitigated_probs, unmitigated_probs], legend=legend, sort="value_desc", bar_labels=False)
+    plot_distribution([mitigated_probs, unmitigated_probs], legend=legend, sort="value_desc", bar_labels=False)
 
 
 Expectation value

--- a/qiskit_experiments/framework/backend_data.py
+++ b/qiskit_experiments/framework/backend_data.py
@@ -22,7 +22,7 @@ from qiskit.providers.fake_provider.fake_backend import FakeBackendV2
 
 try:
     # Removed in Qiskit 1.0. Different from the other FakeBackendV2's
-    from qiskit.providers.fake_provider import FakeBackendV2
+    from qiskit.providers.fake_provider import QiskitFakeBackendV2
 except ImportError:
 
     class QiskitFakeBackendV2:

--- a/qiskit_experiments/framework/backend_data.py
+++ b/qiskit_experiments/framework/backend_data.py
@@ -17,12 +17,12 @@ class unifies data access for various data fields.
 """
 from qiskit.providers.models import PulseBackendConfiguration
 from qiskit.providers import BackendV1, BackendV2
-from qiskit.providers.fake_provider import FakeBackendV2, FakeBackend
+from qiskit.providers.fake_provider import FakeBackend
+from qiskit.providers.fake_provider.fake_backend import FakeBackendV2
 
-# One of the FakeBackendV2's was moved from qiskit to qiskit-ibm-runtime. Check
-# both packages until dropping support for qiskit<1
 try:
-    from qiskit.providers.fake_provider.fake_backend import FakeBackendV2 as QiskitFakeBackendV2
+    # Removed in Qiskit 1.0. Different from the other FakeBackendV2's
+    from qiskit.providers.fake_provider import FakeBackendV2
 except ImportError:
 
     class QiskitFakeBackendV2:
@@ -37,6 +37,8 @@ except ImportError:
 
 
 try:
+    # A copy of qiskit.providers.fake_provider.fake_backend.FakeBackendV2, at
+    # least as of qiskit-ibm-runtime 0.18.0 and Qiskit 1.0
     from qiskit_ibm_runtime.fake_provider.fake_backend import FakeBackendV2 as RuntimeFakeBackendV2
 except ImportError:
 

--- a/qiskit_experiments/framework/backend_data.py
+++ b/qiskit_experiments/framework/backend_data.py
@@ -17,7 +17,38 @@ class unifies data access for various data fields.
 """
 from qiskit.providers.models import PulseBackendConfiguration
 from qiskit.providers import BackendV1, BackendV2
-from qiskit.providers.fake_provider import fake_backend, FakeBackendV2, FakeBackend
+from qiskit.providers.fake_provider import FakeBackendV2, FakeBackend
+
+# One of the FakeBackendV2's was moved from qiskit to qiskit-ibm-runtime. Check
+# both packages until dropping support for qiskit<1
+try:
+    from qiskit.providers.fake_provider.fake_backend import FakeBackendV2 as QiskitFakeBackendV2
+except ImportError:
+
+    class QiskitFakeBackendV2:
+        """Dummy class for when FakeBackendV2 import fails
+
+        This class is only used in isinstance checks. If the import fails, then
+        there won't be an instance of the class either so any dummy class is
+        fine.
+        """
+
+        pass
+
+
+try:
+    from qiskit_ibm_runtime.fake_provider.fake_backend import FakeBackendV2 as RuntimeFakeBackendV2
+except ImportError:
+
+    class RuntimeFakeBackendV2:
+        """Dummy class for when FakeBackendV2 import fails
+
+        This class is only used in isinstance checks. If the import fails, then
+        there won't be an instance of the class either so any dummy class is
+        fine.
+        """
+
+        pass
 
 
 class BackendData:
@@ -255,7 +286,9 @@ class BackendData:
             if self._backend.configuration().simulator or isinstance(self._backend, FakeBackend):
                 return True
         if self._v2:
-            if isinstance(self._backend, (FakeBackendV2, fake_backend.FakeBackendV2)):
+            if isinstance(
+                self._backend, (FakeBackendV2, QiskitFakeBackendV2, RuntimeFakeBackendV2)
+            ):
                 return True
 
         return False

--- a/qiskit_experiments/test/fake_backend.py
+++ b/qiskit_experiments/test/fake_backend.py
@@ -13,14 +13,22 @@
 """Fake backend class for tests."""
 import uuid
 from qiskit.circuit.library import Measure
+from qiskit.providers import ProviderV1
 from qiskit.providers.backend import BackendV2
-from qiskit.providers.fake_provider import FakeProvider
 from qiskit.providers.options import Options
 from qiskit.transpiler import Target
 
 from qiskit.result import Result
 
 from qiskit_experiments.test.utils import FakeJob
+
+
+class FakeProvider(ProviderV1):
+    """Fake provider with no backends for testing"""
+
+    def backends(self, name=None, **kwargs):
+        """List of available backends. Empty in this case"""
+        return []
 
 
 class FakeBackend(BackendV2):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,3 @@
-qiskit==0.45.3
 # Linters
 black~=22.0
 pylint~=3.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy>=1.17
 scipy>=1.4
-qiskit==0.45.3  # Temporary
+qiskit>=0.45
 qiskit-ibm-experiment>=0.3.4
 matplotlib>=3.4
 uncertainties

--- a/test/curve_analysis/test_curve_fitting.py
+++ b/test/curve_analysis/test_curve_fitting.py
@@ -15,7 +15,7 @@ from test.base import QiskitExperimentsTestCase
 import numpy as np
 
 from qiskit import QuantumCircuit, transpile
-from qiskit.providers.basicaer import QasmSimulatorPy
+from qiskit_aer import AerSimulator
 from qiskit_experiments.curve_analysis import process_curve_data
 from qiskit_experiments.curve_analysis.utils import (
     level2_probability,
@@ -36,7 +36,7 @@ class TestCurveFitting(QiskitExperimentsTestCase):
             qc.measure_all()
             circuits.append(qc)
 
-        sim = QasmSimulatorPy()
+        sim = AerSimulator()
         circuits = transpile(circuits, sim)
         job = sim.run(circuits, shots=shots, seed_simulator=10)
         result = job.result()

--- a/test/framework/test_framework.py
+++ b/test/framework/test_framework.py
@@ -13,17 +13,18 @@
 """Tests for base experiment framework."""
 
 import pickle
+from itertools import product
 from test.fake_experiment import FakeExperiment, FakeAnalysis
 from test.base import QiskitExperimentsTestCase
-from itertools import product
+
 import ddt
 
 from qiskit import QuantumCircuit
-from qiskit.providers.fake_provider import FakeJob
 from qiskit.providers.jobstatus import JobStatus
 from qiskit.exceptions import QiskitError
 from qiskit_ibm_runtime.fake_provider import FakeVigoV2
 
+from qiskit_experiments.database_service import Qubit
 from qiskit_experiments.exceptions import AnalysisError
 from qiskit_experiments.framework import (
     ExperimentData,
@@ -33,7 +34,7 @@ from qiskit_experiments.framework import (
     AnalysisStatus,
 )
 from qiskit_experiments.test.fake_backend import FakeBackend
-from qiskit_experiments.database_service import Qubit
+from qiskit_experiments.test.utils import FakeJob
 
 
 @ddt.ddt
@@ -287,7 +288,7 @@ class TestFramework(QiskitExperimentsTestCase):
             """A backend that works with `MyJob`"""
 
             def run(self, run_input, **options):
-                return MyJob(self, "jobid", None)
+                return MyJob(self)
 
         class MyJob(FakeJob):
             """A job with status ERROR, that errors when the result is queried"""

--- a/test/library/calibration/test_rabi.py
+++ b/test/library/calibration/test_rabi.py
@@ -18,8 +18,8 @@ import numpy as np
 from qiskit import QuantumCircuit, pulse, transpile
 from qiskit.exceptions import QiskitError
 from qiskit.circuit import Parameter
-from qiskit.providers.basicaer import QasmSimulatorPy
 from qiskit.qobj.utils import MeasLevel
+from qiskit_aer import AerSimulator
 
 from qiskit_experiments.framework import ExperimentData, ParallelExperiment
 from qiskit_experiments.library import Rabi, EFRabi
@@ -223,7 +223,7 @@ class TestOscillationAnalysis(QiskitExperimentsTestCase):
             qc.measure_all()
             circuits.append(qc)
 
-        sim = QasmSimulatorPy()
+        sim = AerSimulator()
         circuits = transpile(circuits, sim)
         job = sim.run(circuits, shots=shots, seed_simulator=10)
         result = job.result()
@@ -272,7 +272,10 @@ class TestOscillationAnalysis(QiskitExperimentsTestCase):
         """Test the Rabi analysis."""
         experiment_data = ExperimentData()
 
-        thetas = np.linspace(0.0, np.pi / 4, 31)
+        # Change rotation angle with square root of amplitude so that
+        # population versus amplitude will not be sinusoidal and the fit will
+        # be bad.
+        thetas = np.sqrt(np.linspace(0.0, 4 * np.pi**2, 31))
         amplitudes = np.linspace(0.0, 0.95, 31)
 
         experiment_data.add_data(self.simulate_experiment_data(thetas, amplitudes, shots=200))


### PR DESCRIPTION
This change adjusts for several remaining changes in Qiskit 1.0:

* qiskit.providers.basicaer was removed in Qiskit 1.0 (see https://github.com/Qiskit/qiskit/pull/11422). Here its use is replaced with qiskit-aer.

* `qiskit.providers.fake_provider.FakeJob` was removed in Qiskit 1.0 (see https://github.com/Qiskit/qiskit/pull/11376). Here the `FakeJob` already in `qiskit_experiments.test` is used instead. This update was missed in f22bb7b67893a1b75f7d0f1fecdb0bd63284e244 which switched the other `fake_provider` usage.

* Replace `qiskit.provider.FakeProvider` with a custom subclass of `ProviderV1`. `FakeProvider` was moved out of Qiskit 1.0 to qiskit-ibm-runtime.

* `calibration/test_rabi.py` was modified to make the data for a test of bad data worse as the test started fitting the data as good with the original parameters and qiskit-aer in place of basicaer.

* In the readout mitigation manual, a use of `plot_histogram` was exchanged for one of `plot_distribution`.

* Guard `FakeBackendV2` import that was removed in Qiskit 1.0. Try to import `FakeBackendV2` from qiskit-ibm-runtime as well.

Also, this change unpins qiskit which had to be pinned in f22bb7b67893a1b75f7d0f1fecdb0bd63284e244 until these fixes could be merged since 0.46.0 was released with deprecation warnings for some of the usage changed here.