### PR TITLE
Enable loading experiments using the runtime service

### DIFF
--- a/docs/howtos/cloud_service.rst
+++ b/docs/howtos/cloud_service.rst
@@ -45,7 +45,7 @@ backend and not a simulator to be able to save the experiment data. This is done
 .. jupyter-output::
 
     You can view the experiment online at 
-    https://quantum.ibm.com/experiments/10a43cb0-7cb9-41db-ad74-18ea6cf63704
+    https://quantum.ibm.com/experiments/e4fbafb6-3131-49c1-be27-359c609f9af8
 
 Loading
 ~~~~~~~
@@ -56,9 +56,7 @@ experiment <https://quantum.ibm.com/experiments/9640736e-d797-4321-b063-d503f8e9
 
 .. jupyter-input::
 
-    from qiskit_experiments.framework.experiment_data import ExperimentData
-    service = ExperimentData.get_service_from_backend(backend)
-    load_expdata = ExperimentData.load("9640736e-d797-4321-b063-d503f8e98571", service)
+    load_expdata = ExperimentData.load("e4fbafb6-3131-49c1-be27-359c609f9af8", provider=service)
 
 Now we can display the figure from the loaded experiment data:
 

--- a/docs/howtos/cloud_service.rst
+++ b/docs/howtos/cloud_service.rst
@@ -56,6 +56,7 @@ experiment <https://quantum.ibm.com/experiments/9640736e-d797-4321-b063-d503f8e9
 
 .. jupyter-input::
 
+    from qiskit_experiments.framework import ExperimentData
     load_expdata = ExperimentData.load("9640736e-d797-4321-b063-d503f8e98571", provider=service)
 
 Now we can display the figure from the loaded experiment data:

--- a/docs/howtos/cloud_service.rst
+++ b/docs/howtos/cloud_service.rst
@@ -45,7 +45,7 @@ backend and not a simulator to be able to save the experiment data. This is done
 .. jupyter-output::
 
     You can view the experiment online at 
-    https://quantum.ibm.com/experiments/e4fbafb6-3131-49c1-be27-359c609f9af8
+    https://quantum.ibm.com/experiments/10a43cb0-7cb9-41db-ad74-18ea6cf63704
 
 Loading
 ~~~~~~~
@@ -56,7 +56,7 @@ experiment <https://quantum.ibm.com/experiments/9640736e-d797-4321-b063-d503f8e9
 
 .. jupyter-input::
 
-    load_expdata = ExperimentData.load("e4fbafb6-3131-49c1-be27-359c609f9af8", provider=service)
+    load_expdata = ExperimentData.load("9640736e-d797-4321-b063-d503f8e98571", provider=service)
 
 Now we can display the figure from the loaded experiment data:
 

--- a/qiskit_experiments/framework/experiment_data.py
+++ b/qiskit_experiments/framework/experiment_data.py
@@ -1090,14 +1090,16 @@ class ExperimentData:
                     jobs_to_retrieve.append(jid)
 
         for jid in jobs_to_retrieve:
-            try:
-                LOG.debug("Retrieving job [Job ID: %s]", jid)
+            LOG.debug("Retrieving job [Job ID: %s]", jid)
+            try:  # qiskit-ibm-runtime syntax
+                job = self.provider.job(jid)
+                retrieved_jobs[jid] = job
+            except AttributeError:  # TODO: remove this path
                 job = self.provider.retrieve_job(jid)
                 retrieved_jobs[jid] = job
             except Exception:  # pylint: disable=broad-except
                 LOG.warning(
-                    "Unable to retrieve data from job [Job ID: %s]",
-                    jid,
+                    "Unable to retrieve data from job [Job ID: %s]: %s", jid, traceback.format_exc()
                 )
         # Add retrieved job objects to stored jobs and extract data
         for jid, job in retrieved_jobs.items():
@@ -2241,7 +2243,9 @@ class ExperimentData:
             experiment_id: Experiment ID.
             service: the database service.
             provider: an IBMProvider required for loading job data and
-            can be used to initialize the service.
+            can be used to initialize the service. In ``qiskit-ibm-runtime``,
+            this is the ``QiskitRuntimeService`` and should not be confused with
+            the experiment database service.
 
         Returns:
             The loaded experiment data.
@@ -2251,7 +2255,7 @@ class ExperimentData:
         if service is None:
             if provider is None:
                 raise ExperimentDataError(
-                    "Loading an experiment requires a valid ibm provider or experiment service"
+                    "Loading an experiment requires a valid IBM provider or experiment service."
                 )
             service = cls.get_service_from_provider(provider)
         data = service.experiment(experiment_id, json_decoder=cls._json_decoder)
@@ -2545,7 +2549,7 @@ class ExperimentData:
             if hasattr(provider, "_account"):
                 warnings.warn(
                     "qiskit-ibm-provider has been deprecated in favor of qiskit-ibm-runtime. Support"
-                    "for qiskit-ibm-provider backends will be removed in Qiskit Experiments 0.6.",
+                    "for qiskit-ibm-provider backends will be removed in Qiskit Experiments 0.7.",
                     DeprecationWarning,
                     stacklevel=2,
                 )

--- a/qiskit_experiments/framework/experiment_data.py
+++ b/qiskit_experiments/framework/experiment_data.py
@@ -2250,9 +2250,9 @@ class ExperimentData:
             experiment_id: Experiment ID.
             service: the database service.
             provider: an IBMProvider required for loading job data and
-            can be used to initialize the service. In ``qiskit-ibm-runtime``,
-            this is the ``QiskitRuntimeService`` and should not be confused with
-            the experiment database service.
+                can be used to initialize the service. In ``qiskit-ibm-runtime``,
+                this is the ``QiskitRuntimeService`` and should not be confused with
+                the experiment database service.
 
         Returns:
             The loaded experiment data.

--- a/qiskit_experiments/framework/experiment_data.py
+++ b/qiskit_experiments/framework/experiment_data.py
@@ -1094,7 +1094,7 @@ class ExperimentData:
             try:  # qiskit-ibm-runtime syntax
                 job = self.provider.job(jid)
                 retrieved_jobs[jid] = job
-            except AttributeError:  # TODO: remove this path
+            except AttributeError:  # TODO: remove this path for qiskit-ibm-provider
                 try:
                     job = self.provider.retrieve_job(jid)
                     retrieved_jobs[jid] = job
@@ -2262,7 +2262,7 @@ class ExperimentData:
         if service is None:
             if provider is None:
                 raise ExperimentDataError(
-                    "Loading an experiment requires a valid IBM provider or experiment service."
+                    "Loading an experiment requires a valid Qiskit provider or experiment service."
                 )
             service = cls.get_service_from_provider(provider)
         data = service.experiment(experiment_id, json_decoder=cls._json_decoder)

--- a/qiskit_experiments/framework/experiment_data.py
+++ b/qiskit_experiments/framework/experiment_data.py
@@ -1095,8 +1095,15 @@ class ExperimentData:
                 job = self.provider.job(jid)
                 retrieved_jobs[jid] = job
             except AttributeError:  # TODO: remove this path
-                job = self.provider.retrieve_job(jid)
-                retrieved_jobs[jid] = job
+                try:
+                    job = self.provider.retrieve_job(jid)
+                    retrieved_jobs[jid] = job
+                except Exception:  # pylint: disable=broad-except
+                    LOG.warning(
+                        "Unable to retrieve data from job [Job ID: %s]: %s",
+                        jid,
+                        traceback.format_exc(),
+                    )
             except Exception:  # pylint: disable=broad-except
                 LOG.warning(
                     "Unable to retrieve data from job [Job ID: %s]: %s", jid, traceback.format_exc()


### PR DESCRIPTION
### Summary

Follow up to #1371 . `ExperimentData.load()` currently requires the deprecated `qiskit-ibm-provider` provider to load an experiment. This PR allows the provider parameter to take in the `QiskitRuntimeService` service as well. Unfortunately, this is confusing since the experiment service is another parameter for `load()`. We should probably drop the experiment service parameter in a future release and only accept the `QiskitRuntimeService` service.