### PR TITLE
Use a patched qiskit-ibm-runtime when testing Qiskit main

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -35,12 +35,15 @@ commands =
 [testenv:qiskit-main]
 usedevelop = True
 install_command = pip install -U {opts} {packages}
+deps =
+    {[testenv]deps}
+    git+https://github.com/wshanks/qiskit-ibm-runtime.git@no-provider
 commands_pre =
   # We must remove qiskit-terra because some dependencies pull it in and it
   # conflicts with qiskit main. We must remove qiskit-ibm-provider because it gives
   # an import error for qiskit main and it gets automatically imported by qiskit's
   # plugin mechanism.
-  pip uninstall -y qiskit qiskit-terra qiskit-ibm-provider
+  pip uninstall -y qiskit qiskit-terra
   pip install git+https://github.com/Qiskit/qiskit
 commands = stestr run {posargs}
 

--- a/tox.ini
+++ b/tox.ini
@@ -108,9 +108,12 @@ passenv =
   PROD_BUILD
   RELEASE_STRING
   VERSION_STRING
+deps =
+    {[testenv]deps}
+    git+https://github.com/wshanks/qiskit-ibm-runtime.git@no-provider
 commands_pre =
   # See comment for qiskit-main
-  pip uninstall -y qiskit qiskit-terra qiskit-ibm-provider
+  pip uninstall -y qiskit qiskit-terra
   pip install git+https://github.com/Qiskit/qiskit
 commands =
   sphinx-build -j auto -T -W --keep-going -b html {posargs} docs/ docs/_build/html


### PR DESCRIPTION
This change runs the Qiskit main branch tests against a fork of Qiskit runtime with some `Qiskit<1` code (and the qiskit-ibm-provider dependency) removed. It can be undone once qiskit-ibm-runtime releases a version compatible with Qiskit 1.0.