### PR TITLE
Deprecate BackendData.is_simulator

### DIFF
--- a/qiskit_experiments/framework/backend_data.py
+++ b/qiskit_experiments/framework/backend_data.py
@@ -19,6 +19,7 @@ from qiskit.providers.models import PulseBackendConfiguration
 from qiskit.providers import BackendV1, BackendV2
 from qiskit.providers.fake_provider import FakeBackend
 from qiskit.providers.fake_provider.fake_backend import FakeBackendV2
+from qiskit.utils.deprecation import deprecate_func
 
 try:
     # Removed in Qiskit 1.0. Different from the other FakeBackendV2's
@@ -274,6 +275,16 @@ class BackendData:
         return None
 
     @property
+    @deprecate_func(
+        is_property=True,
+        since="0.6",
+        additional_msg=(
+            "is_simulator is deprecated because BackendV2 does not provide a "
+            "standard way for checking this property. Calling code must "
+            "determine if a backend uses a simulator from context."
+        ),
+        package_name="qiskit-experiments",
+    )  # Note: remove all FakeBackend imports when removing this code
     def is_simulator(self):
         """Returns True given an indication the backend is a simulator
 

--- a/releasenotes/notes/deprecate-is-simulator-c101197a126e456f.yaml
+++ b/releasenotes/notes/deprecate-is-simulator-c101197a126e456f.yaml
@@ -1,0 +1,9 @@
+---
+deprecations:
+  - |
+    :attr:`.BackendData.is_simulator` has been deprecated.
+    :class:`~qiskit.providers.BackendV2` does not provide a standard interface
+    for determining if a backend uses a simulator. Calling code must determine
+    if a backend uses a simulator through some other means. Qiskit Experiments
+    does not treat simulator-backed backends differently from hardware backed
+    ones.


### PR DESCRIPTION
No code in qiskit-experiments depends on `is_simulator` already and `BackendV2` does not provide a standard way to check if a backend uses a simulator. The code currently tries checking if a backend is a subclass of some known fake backend classes from qiskit and qiskit-ibm-runtime, but this code is awkward and seems to be doing something awkward for little benefit.