### PR TITLE
Switch back to qiskit-ibm-runtime release for Qiskit main tests

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,7 +12,7 @@ testtools
 
 # Extra dependencies for tests/documentation code
 multimethod
-qiskit-ibm-runtime>=0.18
+qiskit-ibm-runtime>=0.19
 
 # Documentation tools
 arxiv

--- a/tox.ini
+++ b/tox.ini
@@ -36,15 +36,8 @@ commands =
 usedevelop = True
 install_command = pip install -U {opts} {packages}
 deps =
-    {[testenv]deps}
-    git+https://github.com/wshanks/qiskit-ibm-runtime.git@no-provider
-commands_pre =
-  # We must remove qiskit-terra because some dependencies pull it in and it
-  # conflicts with qiskit main. We must remove qiskit-ibm-provider because it gives
-  # an import error for qiskit main and it gets automatically imported by qiskit's
-  # plugin mechanism.
-  pip uninstall -y qiskit qiskit-terra
-  pip install git+https://github.com/Qiskit/qiskit
+  {[testenv]deps}
+  git+https://github.com/Qiskit/qiskit
 commands = stestr run {posargs}
 
 
@@ -109,12 +102,8 @@ passenv =
   RELEASE_STRING
   VERSION_STRING
 deps =
-    {[testenv]deps}
-    git+https://github.com/wshanks/qiskit-ibm-runtime.git@no-provider
-commands_pre =
-  # See comment for qiskit-main
-  pip uninstall -y qiskit qiskit-terra
-  pip install git+https://github.com/Qiskit/qiskit
+  {[testenv]deps}
+  git+https://github.com/Qiskit/qiskit
 commands =
   sphinx-build -j auto -T -W --keep-going -b html {posargs} docs/ docs/_build/html
 


### PR DESCRIPTION
With version 0.19, qiskit-ibm-runtime is now compatible with Qiskit 1.0 and the qiskit-experiments tests pass with Qiskit 1.0.