### PR TITLE
Remove `qiskit_ibm_runtime` import from `MockIQBackend` code

### DIFF
--- a/releasenotes/notes/mock-iq-backend-without-qiskit-runtime-20d2bf9edb48312d.yaml
+++ b/releasenotes/notes/mock-iq-backend-without-qiskit-runtime-20d2bf9edb48312d.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    :class:`.MockIQBackend` was refactored so that it does not import
+    ``qiskit_ibm_runtime`` since
+    :external+qiskit_ibm_runtime:doc:`qiskit-ibm-runtime <index>` is not a
+    required dependency of Qiskit Experiments.


### PR DESCRIPTION
The import was only used for subclassing
`qiskit_ibm_runtime.fake_provider.fake_backend.FakeBackendV2`. The code now subclasses `qiskit.providers.BackendV2` directly.