### PR TITLE
Remove FakeBackendV2 import deprecated in Qiskit 0.46

### DIFF
--- a/qiskit_experiments/framework/backend_data.py
+++ b/qiskit_experiments/framework/backend_data.py
@@ -35,6 +35,7 @@ except ImportError:
 
         pass
 
+
 try:
     # Removed in Qiskit 1.0. Different from the other FakeBackendV2's
     from qiskit.providers.fake_provider import QiskitFakeBackendV2
@@ -49,6 +50,7 @@ except ImportError:
         """
 
         pass
+
 
 try:
     # A copy of qiskit.providers.fake_provider.fake_backend.FakeBackendV2, at

--- a/qiskit_experiments/framework/backend_data.py
+++ b/qiskit_experiments/framework/backend_data.py
@@ -18,8 +18,22 @@ class unifies data access for various data fields.
 from qiskit.providers.models import PulseBackendConfiguration
 from qiskit.providers import BackendV1, BackendV2
 from qiskit.providers.fake_provider import FakeBackend
-from qiskit.providers.fake_provider.fake_backend import FakeBackendV2
 from qiskit.utils.deprecation import deprecate_func
+
+try:
+    # Removed in Qiskit 1.0.
+    from qiskit.providers.fake_provider.fake_backend import FakeBackendV2
+except ImportError:
+
+    class FakeBackendV2:
+        """Dummy class for when FakeBackendV2 import fails
+
+        This class is only used in isinstance checks. If the import fails, then
+        there won't be an instance of the class either so any dummy class is
+        fine.
+        """
+
+        pass
 
 try:
     # Removed in Qiskit 1.0. Different from the other FakeBackendV2's
@@ -35,7 +49,6 @@ except ImportError:
         """
 
         pass
-
 
 try:
     # A copy of qiskit.providers.fake_provider.fake_backend.FakeBackendV2, at


### PR DESCRIPTION
### Summary

In qiskit 0.46, several classes in the `qiskit.providers.fake_provider` module were deprecated, including `qiskit.providers.fake_provider.fake_backend.FakeBackendV2`. However, the removal PR failed to address this particular class, so while this particular `FakeBackendV2` was no longer part of the public API, the import path would still work. This oversight will be addressed in https://github.com/Qiskit/qiskit/pull/11997, but in order to merge this PR we must make sure that all the downstream libraries covered by `qiskit-neko` are up-to-date with the change.

This change adds an alternative import path for this class in qiskit-experiments. It follows the pattern from other 1.0 import deprecations. The removal would roll out in the 1.1 release, but it is indicated as a 1.0 removal because that is when it should have technically taken place.

### Details and comments

Blocks https://github.com/Qiskit/qiskit/pull/11997.
