### PR TITLE
Save experiment and analysis config as artifacts

### DIFF
--- a/qiskit_experiments/framework/base_analysis.py
+++ b/qiskit_experiments/framework/base_analysis.py
@@ -154,6 +154,9 @@ class BaseAnalysis(ABC, StoreInitArgs):
             will be returned containing only the new analysis results and figures.
             This data can then be saved as its own experiment to a database service.
         """
+        experiment_data.add_artifacts(
+            ArtifactData(name="analysis_options", data=self.options), overwrite_name=True
+        )
         # Make a new copy of experiment data if not updating results
         if not replace_results and _requires_copy(experiment_data):
             experiment_data = experiment_data.copy()
@@ -166,8 +169,7 @@ class BaseAnalysis(ABC, StoreInitArgs):
             analysis.set_options(**options)
 
         def run_analysis(expdata: ExperimentData):
-            # Clearing previous analysis data
-            experiment_data._clear_results()
+            experiment_data._clear_results(delete_artifacts=False)
 
             if not expdata.data():
                 warnings.warn("ExperimentData object data is empty.\n")

--- a/qiskit_experiments/framework/base_analysis.py
+++ b/qiskit_experiments/framework/base_analysis.py
@@ -155,7 +155,7 @@ class BaseAnalysis(ABC, StoreInitArgs):
             This data can then be saved as its own experiment to a database service.
         """
         experiment_data.add_artifacts(
-            ArtifactData(name="analysis_options", data=self.options), overwrite_name=True
+            ArtifactData(name="analysis_config", data=self.config()), overwrite_name=True
         )
         # Make a new copy of experiment data if not updating results
         if not replace_results and _requires_copy(experiment_data):

--- a/qiskit_experiments/framework/experiment_data.py
+++ b/qiskit_experiments/framework/experiment_data.py
@@ -2686,7 +2686,7 @@ class ExperimentData:
                 keys = self._find_artifact_keys(artifact.name)
                 if keys:
                     for key in keys:
-                        self._artifacts[key] = artifact 
+                        self._artifacts[key] = artifact
                 else:
                     self._artifacts[artifact.artifact_id] = artifact
             else:

--- a/test/database_service/test_db_experiment_data.py
+++ b/test/database_service/test_db_experiment_data.py
@@ -1272,7 +1272,7 @@ class TestDbExperimentData(QiskitExperimentsTestCase):
         self.assertEqual(exp_data.metadata["artifact_files"], {"test2.zip"})
 
     def test_add_duplicated_artifact(self):
-        """Tests behavior when adding an artifact with a duplicate ID."""
+        """Tests behavior when adding an artifact with a duplicate ID/name."""
         exp_data = ExperimentData()
 
         new_artifact1 = ArtifactData(artifact_id="0", name="test", data="foo")
@@ -1285,8 +1285,13 @@ class TestDbExperimentData(QiskitExperimentsTestCase):
             exp_data.add_artifacts(new_artifact2)
 
         # Overwrite the artifact with a new one of the same ID
-        exp_data.add_artifacts(new_artifact2, overwrite=True)
+        exp_data.add_artifacts(new_artifact2, overwrite_id=True)
         self.assertEqual(exp_data.artifacts(), [new_artifact2])
+
+        # Overwrite the artifact with a new one of the same name
+        new_artifact3 = ArtifactData(name="test", data="foo2")
+        exp_data.add_artifacts(new_artifact3, overwrite_name=True)
+        self.assertEqual(exp_data.artifacts(), [new_artifact2, new_artifact3])
 
     def test_delete_nonexistent_artifact(self):
         """Tests behavior when deleting a nonexistent artifact."""


### PR DESCRIPTION
### Summary

Saves experiment and analysis config as `experiment_config` and `analysis_config` in experiment data artifacts. Because `analysis_options` shouldn't be added as a new artifact every time analysis is rerun, this also adds `overwrite_name` option to `add_artifacts()` and renames the current `overwrite` option to `overwrite_id`.