### PR TITLE
Update SingleTransmonTestBackend for Qiskit Dynamics 0.5.0

### DIFF
--- a/releasenotes/notes/dynamics-0.5-0da56d1ef7d93e77.yaml
+++ b/releasenotes/notes/dynamics-0.5-0da56d1ef7d93e77.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    :class:`.SingleTransmonTestBackend` was updated to be compatible with
+    :mod:`qiskit_dynamics` version 0.5.0. The updates accounted for changes in
+    the expected arguments to Dynamics API's and did not change behavior. See
+    `#1427
+    <https://github.com/Qiskit-Extensions/qiskit-experiments/pull/1427>`__.

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ uncertainties
 lmfit
 rustworkx
 pandas>=1.1.5
+packaging


### PR DESCRIPTION
Dynamics 0.5.0 changed the arguments it expects for Solver and underlying models. In particular, instead of `evaluation_mode`, `array_library` and `vectorized` are expected. See https://qiskit-extensions.github.io/qiskit-dynamics/release_notes.html#release-notes-0-5-0