### PR TITLE
Fix a bug in EPG computation for devices with ECR gates

### DIFF
--- a/docs/manuals/verification/randomized_benchmarking.rst
+++ b/docs/manuals/verification/randomized_benchmarking.rst
@@ -208,6 +208,8 @@ The EPGs of two-qubit RB are analyzed with the corrected EPC if available.
 
 Note that ``EPC_corrected`` value is smaller than one of raw ``EPC``, which indicates
 contribution of depolarization from single-qubit error channels.
+If you don't need ``EPG`` value, you can skip its computation by
+``exp_2q.analysis.set_options(gate_error_ratio=False)``.
 
 
 Displaying the RB circuits

--- a/qiskit_experiments/library/randomized_benchmarking/rb_analysis.py
+++ b/qiskit_experiments/library/randomized_benchmarking/rb_analysis.py
@@ -324,6 +324,7 @@ def _lookup_epg_ratio(gate: str, n_qubits: int) -> Union[None, int]:
         "cy": 1.0,
         "cz": 1.0,
         "ch": 1.0,
+        "ecr": 1.0,
         "crx": 2.0,
         "cry": 2.0,
         "crz": 2.0,

--- a/releasenotes/notes/fix-ecr-epg-59c8db98494966b0.yaml
+++ b/releasenotes/notes/fix-ecr-epg-59c8db98494966b0.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    Fixed a bug in EPG (error per gate) computation in :class:`~.RBAnalysis`
+    where it fails with a ``TypeError`` for backends with ECR gate
+    as a 2-qubit basis gate (e.g. IBM Eagle processors).
+    See
+    `#1419
+    <https://github.com/Qiskit-Extensions/qiskit-experiments/pull/1419>`_.
+    for the details of the bug.


### PR DESCRIPTION
### Summary
Fixed a bug in EPG (error per gate) computation in `RBAnalysis` where it fails with a ``TypeError`` for backends with ECR gate as a 2-qubit basis gate (e.g. IBM Eagle processors).
Fixed #1419 .

### Details and comments
Added the standard gate error ratio (`1.0`) for ECR gate as suggested in the issue. Also added a sentence to explain how to skip EPG computation in the manual.