### PR TITLE
Update copy analysis result and experiment data behavior

### DIFF
--- a/qiskit_experiments/framework/experiment_data.py
+++ b/qiskit_experiments/framework/experiment_data.py
@@ -2396,7 +2396,10 @@ class ExperimentData:
         # Copy results and figures.
         # This requires analysis callbacks to finish
         self._wait_for_futures(self._analysis_futures.values(), name="analysis")
-        new_instance._analysis_results = self._analysis_results.copy()
+        copied_results = self._analysis_results.copy()
+        # Analysis results should have experiment ID of the copied experiment
+        copied_results._data["experiment_id"] = new_instance.experiment_id
+        new_instance._analysis_results = copied_results
         with self._figures.lock:
             new_instance._figures = ThreadSafeOrderedDict()
             new_instance.add_figures(self._figures.values())

--- a/releasenotes/notes/fix-copy-analysis-results-e7a8381a7b720f47.yaml
+++ b/releasenotes/notes/fix-copy-analysis-results-e7a8381a7b720f47.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixed a bug where a copied :class:`.ExperimentData` instance's analysis results didn't get
+    new IDs and experiement ID.


### PR DESCRIPTION
### Summary

Fixes #1396. When an `ExperimentData` object was copied, it didn't update the analysis result IDs and their associated experiment IDs, resulting in the copied experiment entry not having analysis results in the cloud service.

### Details and comments

- The code to to assign new result IDs when copying an `AnalysisResultTable` isn't very efficient because it has to loop through the rows and call `_create_unique_hash()` for each ID. Maybe this logic can be refactored.