### PR TITLE
Temporary workaround for github actions worktreeconfig issues

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -97,6 +97,9 @@ jobs:
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-docs-${{ hashFiles('setup.py','requirements.txt','requirements-extras.txt','requirements-dev.txt','constraints.txt') }}
+      - name: Temporary workaround for git worktreeconfig
+        run: |
+          git config --global --unset extensions.worktreeConfig
       - name: Install Deps
         run: |
           python -m pip install -U tox

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,6 +88,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Temporary workaround for GitVersion
+        shell: bash
+        run: |
+          git config --unset-all extensions.worktreeconfig
       - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
@@ -97,9 +101,6 @@ jobs:
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-docs-${{ hashFiles('setup.py','requirements.txt','requirements-extras.txt','requirements-dev.txt','constraints.txt') }}
-      - name: Temporary workaround for git worktreeconfig
-        run: |
-          git config --global --unset extensions.worktreeConfig
       - name: Install Deps
         run: |
           python -m pip install -U tox


### PR DESCRIPTION
Temporary fix to get the docs CI to run again from https://github.com/GitTools/actions/issues/1115. Also see https://github.com/jelmer/dulwich/issues/1285.