### PR TITLE
Disable git worktrees

### DIFF
--- a/.github/workflows/docs_dev.yml
+++ b/.github/workflows/docs_dev.yml
@@ -21,6 +21,11 @@ jobs:
         python -m pip install --upgrade pip
         pip install -U virtualenv setuptools wheel tox
         sudo apt-get install graphviz pandoc
+    - name: Temporary workaround for GitVersion
+      shell: bash
+      run: |
+        git config --unset-all extensions.worktreeconfig
+        # See https://github.com/GitTools/actions/issues/1115
     - name: Build docs dev
       run: EXPERIMENTS_DEV_DOCS=1 PROD_BUILD=1 RELEASE_STRING=`git describe` tox -edocs
     - name: Bypass Jekyll Processing # Necessary for setting the correct css path


### PR DESCRIPTION
While investigating a Sphinx Ci failure in circuit-knitting-toolbox, I noticed the `qiskit-experiments` repository's CI was failing for the same reason. I will propose the same temporary fix to the docs workflow in this PR that I submitted to CKT.

There is a [problem with dulwich](https://github.com/jelmer/dulwich/issues/1285) (used by reno) and git worktrees. This PR implements a temporary fix, spelled out [here](https://github.com/GitTools/actions/issues/1115#issuecomment-2070736857).