### PR TITLE
Update MacOS runner and revert #1443

### DIFF
--- a/.github/workflows/cron-staging.yml
+++ b/.github/workflows/cron-staging.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.8, "3.12"]
-        os: ["ubuntu-latest", "macOS-latest", "windows-latest"]
+        os: ["ubuntu-latest", "macos-13", "windows-latest"]
     steps:
       - name: Print Concurrency Group
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.8, "3.12"]
-        os: ["ubuntu-latest", "macOS-latest", "windows-latest"]
+        os: ["ubuntu-latest", "macos-13", "windows-latest"]
     steps:
       - name: Print Concurrency Group
         env:
@@ -88,10 +88,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Temporary workaround for GitVersion
-        shell: bash
-        run: |
-          git config --unset-all extensions.worktreeconfig
       - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
Reverts #1443 since dulwich made a new release with @wshanks's fix. Also updates the mac test runner to `macos-13` since `macOS-latest` is now arm-based and no longer supports python3.8. We should eventually follow https://github.com/Qiskit/qiskit/pull/12102 and add arm support. 