### PR TITLE
Ignore unset hub/group/project field on backend

### DIFF
--- a/qiskit_experiments/framework/experiment_data.py
+++ b/qiskit_experiments/framework/experiment_data.py
@@ -587,7 +587,7 @@ class ExperimentData:
         if provider is not None:
             self._set_hgp_from_provider(provider)
         # qiskit-ibm-runtime style
-        elif hasattr(self._backend, "_instance"):
+        elif hasattr(self._backend, "_instance") and self._backend._instance:
             self.hgp = self._backend._instance
         if recursive:
             for data in self.child_data():


### PR DESCRIPTION
In some cases, backends can be created without the `_instance` field set (so it is `None`). In this case, it is better to ignore the field than to raise an uncaught exception.