### PR TITLE
Fast transpile with MixIn

### DIFF
--- a/qiskit_experiments/framework/__init__.py
+++ b/qiskit_experiments/framework/__init__.py
@@ -125,7 +125,7 @@ Experiment Configuration Helper Classes
     BackendData
     BackendTiming
     RestlessMixin
-    SimpleCircuitExtender
+    SimpleCircuitExtenderMixin
 
     """
 from qiskit.providers.options import Options
@@ -156,4 +156,4 @@ from .composite import (
 )
 from .json import ExperimentEncoder, ExperimentDecoder
 from .restless_mixin import RestlessMixin
-from .transpile_mixin import SimpleCircuitExtender
+from .transpile_mixin import SimpleCircuitExtenderMixin

--- a/qiskit_experiments/framework/__init__.py
+++ b/qiskit_experiments/framework/__init__.py
@@ -125,8 +125,9 @@ Experiment Configuration Helper Classes
     BackendData
     BackendTiming
     RestlessMixin
+    SimpleCircuitExtender
 
-"""
+    """
 from qiskit.providers.options import Options
 from qiskit_experiments.framework.backend_data import BackendData
 from qiskit_experiments.framework.analysis_result import AnalysisResult
@@ -155,3 +156,4 @@ from .composite import (
 )
 from .json import ExperimentEncoder, ExperimentDecoder
 from .restless_mixin import RestlessMixin
+from .transpile_mixin import SimpleCircuitExtender

--- a/qiskit_experiments/framework/transpile_mixin.py
+++ b/qiskit_experiments/framework/transpile_mixin.py
@@ -1,0 +1,72 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Transpile mixin class."""
+
+from __future__ import annotations
+from typing import Protocol
+
+from qiskit import QuantumCircuit, QuantumRegister
+from qiskit.providers import Backend
+
+
+class TranspileMixInProtocol(Protocol):
+    """A protocol to define a class that can be mixed with transpiler mixins."""
+
+    @property
+    def physical_qubits(self):
+        ...
+
+    @property
+    def backend(self) -> Backend | None:
+        ...
+
+    def circuits(self) -> list[QuantumCircuit]:
+        ...
+
+    def _transpiled_circuits(self) -> list[QuantumCircuit]:
+        ...
+
+
+class SimpleCircuitExtender:
+    """A transpiler mixin class that maps virtual qubit index to physical.
+
+    Experiment class returns virtual circuits when the backend is not set.
+    """
+
+    def _transpiled_circuits(
+        self: TranspileMixInProtocol,
+    ) -> list:
+        if hasattr(self.backend, "num_qubits"):
+            # V2 backend model
+            n_qubits = self.backend.num_qubits
+        elif hasattr(self.backend, "configuration"):
+            # V1 backend model
+            n_qubits = self.backend.configuration().n_qubits
+        else:
+            # Backend is not set. Return virtual circuits as is.
+            return self.circuits()
+        return [self._index_mapper(c, n_qubits) for c in self.circuits()]
+
+    def _index_mapper(
+        self: TranspileMixInProtocol,
+        v_circ: QuantumCircuit,
+        n_qubits: int,
+    ) -> QuantumCircuit:
+        p_qregs = QuantumRegister(n_qubits)
+        v_p_map = {q: p_qregs[self.physical_qubits[i]] for i, q in enumerate(v_circ.qubits)}
+        p_circ = QuantumCircuit(p_qregs, *v_circ.cregs)
+        p_circ.metadata = v_circ.metadata
+        for inst, v_qubits, clbits in v_circ.data:
+            p_qubits = list(map(v_p_map.get, v_qubits))
+            p_circ._append(inst, p_qubits, clbits)
+        return p_circ

--- a/qiskit_experiments/library/characterization/t1.py
+++ b/qiskit_experiments/library/characterization/t1.py
@@ -19,11 +19,16 @@ import numpy as np
 from qiskit.circuit import QuantumCircuit
 from qiskit.providers.backend import Backend
 
-from qiskit_experiments.framework import BackendTiming, BaseExperiment, Options
+from qiskit_experiments.framework import (
+    SimpleCircuitExtender,
+    BackendTiming,
+    BaseExperiment,
+    Options,
+)
 from qiskit_experiments.library.characterization.analysis.t1_analysis import T1Analysis
 
 
-class T1(BaseExperiment):
+class T1(SimpleCircuitExtender, BaseExperiment):
     r"""An experiment to measure the qubit relaxation time.
 
     # section: overview

--- a/qiskit_experiments/library/characterization/t1.py
+++ b/qiskit_experiments/library/characterization/t1.py
@@ -20,7 +20,7 @@ from qiskit.circuit import QuantumCircuit
 from qiskit.providers.backend import Backend
 
 from qiskit_experiments.framework import (
-    SimpleCircuitExtender,
+    SimpleCircuitExtenderMixin,
     BackendTiming,
     BaseExperiment,
     Options,
@@ -28,7 +28,7 @@ from qiskit_experiments.framework import (
 from qiskit_experiments.library.characterization.analysis.t1_analysis import T1Analysis
 
 
-class T1(SimpleCircuitExtender, BaseExperiment):
+class T1(SimpleCircuitExtenderMixin, BaseExperiment):
     r"""An experiment to measure the qubit relaxation time.
 
     # section: overview

--- a/qiskit_experiments/library/characterization/t2hahn.py
+++ b/qiskit_experiments/library/characterization/t2hahn.py
@@ -20,16 +20,11 @@ from qiskit import QuantumCircuit, QiskitError
 from qiskit.circuit import Parameter
 from qiskit.providers.backend import Backend
 
-from qiskit_experiments.framework import (
-    SimpleCircuitExtender,
-    BackendTiming,
-    BaseExperiment,
-    Options,
-)
+from qiskit_experiments.framework import BackendTiming, BaseExperiment, Options
 from qiskit_experiments.library.characterization.analysis.t2hahn_analysis import T2HahnAnalysis
 
 
-class T2Hahn(SimpleCircuitExtender, BaseExperiment):
+class T2Hahn(BaseExperiment):
     r"""An experiment to measure the dephasing time insensitive to inhomogeneous
     broadening using Hahn echos.
 

--- a/qiskit_experiments/library/characterization/t2hahn.py
+++ b/qiskit_experiments/library/characterization/t2hahn.py
@@ -20,11 +20,16 @@ from qiskit import QuantumCircuit, QiskitError
 from qiskit.circuit import Parameter
 from qiskit.providers.backend import Backend
 
-from qiskit_experiments.framework import BackendTiming, BaseExperiment, Options
+from qiskit_experiments.framework import (
+    SimpleCircuitExtender,
+    BackendTiming,
+    BaseExperiment,
+    Options,
+)
 from qiskit_experiments.library.characterization.analysis.t2hahn_analysis import T2HahnAnalysis
 
 
-class T2Hahn(BaseExperiment):
+class T2Hahn(SimpleCircuitExtender, BaseExperiment):
     r"""An experiment to measure the dephasing time insensitive to inhomogeneous
     broadening using Hahn echos.
 

--- a/qiskit_experiments/library/characterization/t2ramsey.py
+++ b/qiskit_experiments/library/characterization/t2ramsey.py
@@ -21,11 +21,16 @@ import qiskit
 from qiskit import QuantumCircuit
 from qiskit.providers.backend import Backend
 
-from qiskit_experiments.framework import BackendTiming, BaseExperiment, Options
+from qiskit_experiments.framework import (
+    SimpleCircuitExtender,
+    BackendTiming,
+    BaseExperiment,
+    Options,
+)
 from qiskit_experiments.library.characterization.analysis.t2ramsey_analysis import T2RamseyAnalysis
 
 
-class T2Ramsey(BaseExperiment):
+class T2Ramsey(SimpleCircuitExtender, BaseExperiment):
     r"""An experiment to measure the Ramsey frequency and the qubit dephasing time
     sensitive to inhomogeneous broadening.
 

--- a/qiskit_experiments/library/characterization/t2ramsey.py
+++ b/qiskit_experiments/library/characterization/t2ramsey.py
@@ -22,7 +22,7 @@ from qiskit import QuantumCircuit
 from qiskit.providers.backend import Backend
 
 from qiskit_experiments.framework import (
-    SimpleCircuitExtender,
+    SimpleCircuitExtenderMixin,
     BackendTiming,
     BaseExperiment,
     Options,
@@ -30,7 +30,7 @@ from qiskit_experiments.framework import (
 from qiskit_experiments.library.characterization.analysis.t2ramsey_analysis import T2RamseyAnalysis
 
 
-class T2Ramsey(SimpleCircuitExtender, BaseExperiment):
+class T2Ramsey(SimpleCircuitExtenderMixin, BaseExperiment):
     r"""An experiment to measure the Ramsey frequency and the qubit dephasing time
     sensitive to inhomogeneous broadening.
 

--- a/releasenotes/notes/add-transpiler-mixin-9b30296518e5f4ba.yaml
+++ b/releasenotes/notes/add-transpiler-mixin-9b30296518e5f4ba.yaml
@@ -1,7 +1,7 @@
 ---
 developer:
   - |
-    Add a mixin class :class:`~.SimpleCircuitExtender` that automatically
+    Add a mixin class :class:`~.SimpleCircuitExtenderMixin` that automatically
     implements the :meth:`.BaseExperiment._transpiled_circuits` method for 
     simple experiments that require neither gate translation nor routing,
     i.e. experiment that directly creates ISA circuits.
@@ -10,9 +10,9 @@ developer:
 
     .. code-block::python
 
-      from qiskit_experiment.framework import BaseExperiment, SimpleCircuitExtender
+      from qiskit_experiment.framework import BaseExperiment, SimpleCircuitExtenderMixin
 
-      class MyExperiment(SimpleCircuitExtender, BaseExperiment):
+      class MyExperiment(SimpleCircuitExtenderMixin, BaseExperiment):
 
         def circuits(self):
           qc = QuantumCircuit(1, 1)

--- a/releasenotes/notes/add-transpiler-mixin-9b30296518e5f4ba.yaml
+++ b/releasenotes/notes/add-transpiler-mixin-9b30296518e5f4ba.yaml
@@ -1,72 +1,21 @@
 ---
-prelude: >
-    Replace this text with content to appear at the top of the section for this
-    release. All of the prelude content is merged together and then rendered
-    separately from the items listed in other parts of the file, so the text
-    needs to be worded so that both the prelude and the other items make sense
-    when read independently. This may mean repeating some details. Not every
-    release note requires a prelude. Usually only notes describing major
-    features or adding release theme details should have a prelude.
-features:
-  - |
-    List new features here, or remove this section.  All of the list items in
-    this section are combined when the release notes are rendered, so the text
-    needs to be worded so that it does not depend on any information only
-    available in another section, such as the prelude. This may mean repeating
-    some details.
-issues:
-  - |
-    List known issues here, or remove this section.  All of the list items in
-    this section are combined when the release notes are rendered, so the text
-    needs to be worded so that it does not depend on any information only
-    available in another section, such as the prelude. This may mean repeating
-    some details.
-upgrade:
-  - |
-    List upgrade notes here, or remove this section.  All of the list items in
-    this section are combined when the release notes are rendered, so the text
-    needs to be worded so that it does not depend on any information only
-    available in another section, such as the prelude. This may mean repeating
-    some details.
-deprecations:
-  - |
-    List deprecations notes here, or remove this section.  All of the list
-    items in this section are combined when the release notes are rendered, so
-    the text needs to be worded so that it does not depend on any information
-    only available in another section, such as the prelude. This may mean
-    repeating some details.
-critical:
-  - |
-    Add critical notes here, or remove this section.  All of the list items in
-    this section are combined when the release notes are rendered, so the text
-    needs to be worded so that it does not depend on any information only
-    available in another section, such as the prelude. This may mean repeating
-    some details.
-security:
-  - |
-    Add security notes here, or remove this section.  All of the list items in
-    this section are combined when the release notes are rendered, so the text
-    needs to be worded so that it does not depend on any information only
-    available in another section, such as the prelude. This may mean repeating
-    some details.
-fixes:
-  - |
-    Add normal bug fixes here, or remove this section.  All of the list items
-    in this section are combined when the release notes are rendered, so the
-    text needs to be worded so that it does not depend on any information only
-    available in another section, such as the prelude. This may mean repeating
-    some details.
 developer:
   - |
-    Add upgrade of protected-level API (e.g. hooks). All of the list items
-    in this section are combined when the release notes are rendered, so the
-    text needs to be worded so that it does not depend on any information only
-    available in another section, such as the prelude. This may mean repeating
-    some details.
-other:
-  - |
-    Add other notes here, or remove this section.  All of the list items in
-    this section are combined when the release notes are rendered, so the text
-    needs to be worded so that it does not depend on any information only
-    available in another section, such as the prelude. This may mean repeating
-    some details.
+    Add a mixin class :class:`~.SimpleCircuitExtender` that automatically
+    implements the :meth:`.BaseExperiment._transpiled_circuits` method for 
+    simple experiments that require neither gate translation nor routing,
+    i.e. experiment that directly creates ISA circuits.
+    This bypasses the call to the Qiskit transpiler, which makes your experiment run more performant.
+    For example:
+
+    .. code-block::python
+
+      from qiskit_experiment.framework import BaseExperiment, SimpleCircuitExtender
+
+      class MyExperiment(SimpleCircuitExtender, BaseExperiment):
+
+        def circuits(self):
+          qc = QuantumCircuit(1, 1)
+          qc.x(0)
+          qc.measure(0, 0)
+          return [qc]

--- a/releasenotes/notes/add-transpiler-mixin-9b30296518e5f4ba.yaml
+++ b/releasenotes/notes/add-transpiler-mixin-9b30296518e5f4ba.yaml
@@ -1,0 +1,72 @@
+---
+prelude: >
+    Replace this text with content to appear at the top of the section for this
+    release. All of the prelude content is merged together and then rendered
+    separately from the items listed in other parts of the file, so the text
+    needs to be worded so that both the prelude and the other items make sense
+    when read independently. This may mean repeating some details. Not every
+    release note requires a prelude. Usually only notes describing major
+    features or adding release theme details should have a prelude.
+features:
+  - |
+    List new features here, or remove this section.  All of the list items in
+    this section are combined when the release notes are rendered, so the text
+    needs to be worded so that it does not depend on any information only
+    available in another section, such as the prelude. This may mean repeating
+    some details.
+issues:
+  - |
+    List known issues here, or remove this section.  All of the list items in
+    this section are combined when the release notes are rendered, so the text
+    needs to be worded so that it does not depend on any information only
+    available in another section, such as the prelude. This may mean repeating
+    some details.
+upgrade:
+  - |
+    List upgrade notes here, or remove this section.  All of the list items in
+    this section are combined when the release notes are rendered, so the text
+    needs to be worded so that it does not depend on any information only
+    available in another section, such as the prelude. This may mean repeating
+    some details.
+deprecations:
+  - |
+    List deprecations notes here, or remove this section.  All of the list
+    items in this section are combined when the release notes are rendered, so
+    the text needs to be worded so that it does not depend on any information
+    only available in another section, such as the prelude. This may mean
+    repeating some details.
+critical:
+  - |
+    Add critical notes here, or remove this section.  All of the list items in
+    this section are combined when the release notes are rendered, so the text
+    needs to be worded so that it does not depend on any information only
+    available in another section, such as the prelude. This may mean repeating
+    some details.
+security:
+  - |
+    Add security notes here, or remove this section.  All of the list items in
+    this section are combined when the release notes are rendered, so the text
+    needs to be worded so that it does not depend on any information only
+    available in another section, such as the prelude. This may mean repeating
+    some details.
+fixes:
+  - |
+    Add normal bug fixes here, or remove this section.  All of the list items
+    in this section are combined when the release notes are rendered, so the
+    text needs to be worded so that it does not depend on any information only
+    available in another section, such as the prelude. This may mean repeating
+    some details.
+developer:
+  - |
+    Add upgrade of protected-level API (e.g. hooks). All of the list items
+    in this section are combined when the release notes are rendered, so the
+    text needs to be worded so that it does not depend on any information only
+    available in another section, such as the prelude. This may mean repeating
+    some details.
+other:
+  - |
+    Add other notes here, or remove this section.  All of the list items in
+    this section are combined when the release notes are rendered, so the text
+    needs to be worded so that it does not depend on any information only
+    available in another section, such as the prelude. This may mean repeating
+    some details.

--- a/test/framework/test_transpile_mixin.py
+++ b/test/framework/test_transpile_mixin.py
@@ -12,8 +12,6 @@
 
 """Tests for transpile mixin."""
 
-from typing import Sequence
-
 from test.base import QiskitExperimentsTestCase
 from test.fake_experiment import FakeAnalysis
 

--- a/test/framework/test_transpile_mixin.py
+++ b/test/framework/test_transpile_mixin.py
@@ -1,0 +1,119 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Tests for transpile mixin."""
+
+from test.base import QiskitExperimentsTestCase
+
+from qiskit import QuantumCircuit
+from qiskit.providers.fake_provider import GenericBackendV2
+
+from qiskit_experiments.framework import SimpleCircuitExtender, BaseExperiment
+
+
+class TestSimpleCircuitExtender(QiskitExperimentsTestCase):
+    """A test for SimpleCircuitExtender MixIn."""
+
+    def test_transpiled_single_qubit_circuits(self):
+        """Test fast-transpile with single qubit circuit."""
+
+        class _MockExperiment(SimpleCircuitExtender, BaseExperiment):
+            def circuits(self) -> list:
+                qc1 = QuantumCircuit(1, 1)
+                qc1.x(0)
+                qc1.measure(0, 0)
+                qc1.metadata = {"test_val": "123"}
+
+                qc2 = QuantumCircuit(1, 1)
+                qc2.sx(0)
+                qc2.measure(0, 0)
+                qc2.metadata = {"test_val": "456"}
+                return [qc1, qc2]
+
+        num_qubits = 10
+
+        mock_backend = GenericBackendV2(num_qubits, basis_gates=["sx", "rz", "x"])
+        exp = _MockExperiment((3,), backend=mock_backend)
+        test_circs = exp._transpiled_circuits()
+
+        self.assertEqual(len(test_circs), 2)
+        c0, c1 = test_circs
+
+        # output size
+        self.assertEqual(len(c0.qubits), num_qubits)
+        self.assertEqual(len(c1.qubits), num_qubits)
+
+        # metadata
+        self.assertDictEqual(c0.metadata, {"test_val": "123"})
+
+        # qubit index of X gate
+        self.assertEqual(c0.qubits.index(c0.data[0][1][0]), 3)
+
+        # creg index of measure
+        self.assertEqual(c0.clbits.index(c0.data[1][2][0]), 0)
+
+        # metadata
+        self.assertDictEqual(c1.metadata, {"test_val": "456"})
+
+        # qubit index of SX gate
+        self.assertEqual(c1.qubits.index(c1.data[0][1][0]), 3)
+
+        # creg index of measure
+        self.assertEqual(c1.clbits.index(c1.data[1][2][0]), 0)
+
+    def test_transpiled_two_qubit_circuits(self):
+        """Test fast-transpile with two qubit circuit."""
+
+        class _MockExperiment(SimpleCircuitExtender, BaseExperiment):
+            def circuits(self) -> list:
+                qc = QuantumCircuit(2, 2)
+                qc.cx(0, 1)
+                qc.measure(0, 0)
+                qc.measure(1, 1)
+                return [qc]
+
+        num_qubits = 10
+
+        mock_backend = GenericBackendV2(num_qubits, basis_gates=["sx", "rz", "x", "cx"])
+        exp = _MockExperiment((9, 2), backend=mock_backend)
+        test_circ = exp._transpiled_circuits()[0]
+
+        self.assertEqual(len(test_circ.qubits), num_qubits)
+
+        # qubit index of CX control qubit
+        self.assertEqual(test_circ.qubits.index(test_circ.data[0][1][0]), 9)
+
+        # qubit index of CX target qubit
+        self.assertEqual(test_circ.qubits.index(test_circ.data[0][1][1]), 2)
+
+        # creg index of measure
+        self.assertEqual(test_circ.clbits.index(test_circ.data[1][2][0]), 0)
+        self.assertEqual(test_circ.clbits.index(test_circ.data[2][2][0]), 1)
+
+    def test_empty_backend(self):
+        """Test fast-transpile without backend, which must return virtual circuit."""
+
+        class _MockExperiment(SimpleCircuitExtender, BaseExperiment):
+            def circuits(self) -> list:
+                qc = QuantumCircuit(1, 1)
+                qc.x(0)
+                qc.measure(0, 0)
+
+                return [qc]
+
+        exp = _MockExperiment((10,))
+        test_circ = exp._transpiled_circuits()[0]
+
+        self.assertEqual(len(test_circ.qubits), 1)
+
+        # qubit index of X gate
+        self.assertEqual(test_circ.qubits.index(test_circ.data[0][1][0]), 0)

--- a/test/library/characterization/test_t1.py
+++ b/test/library/characterization/test_t1.py
@@ -252,7 +252,7 @@ class TestT1(QiskitExperimentsTestCase):
         instruction_durations = []
         for i in range(num_qubits):
             instruction_durations += [
-                ("rx", [i], (i + 1) * 10, "ns"),
+                ("x", [i], (i + 1) * 10, "ns"),
                 ("measure", [i], (i + 1) * 1000, "ns"),
             ]
         coupling_map = [[i - 1, i] for i in range(1, num_qubits)]
@@ -272,14 +272,14 @@ class TestT1(QiskitExperimentsTestCase):
         for circ in circs:
             self.assertEqual(circ.num_qubits, 2)
             op_counts = circ.count_ops()
-            self.assertEqual(op_counts.get("rx"), 2)
+            self.assertEqual(op_counts.get("x"), 2)
             self.assertEqual(op_counts.get("delay"), 2)
 
         tcircs = parexp._transpiled_circuits()
         for circ in tcircs:
             self.assertEqual(circ.num_qubits, num_qubits)
             op_counts = circ.count_ops()
-            self.assertEqual(op_counts.get("rx"), 2)
+            self.assertEqual(op_counts.get("x"), 2)
             self.assertEqual(op_counts.get("delay"), 2)
 
     def test_experiment_config(self):


### PR DESCRIPTION
### Summary

Call to Qiskit transpiler is overkill for simple experiment that directly creates ISA circuits, like T1 and T2 experiment. This PR adds a mixin class that automatically implements `_transpiled_circuits()` method that only maps virtual qubit index to physical qubit index without invoking the computationally heavy transpiler.

### Details and comments

