### PR TITLE
Update version string in stable docs deploy CI

### DIFF
--- a/.github/workflows/docs_stable.yml
+++ b/.github/workflows/docs_stable.yml
@@ -30,7 +30,7 @@ jobs:
         run: touch docs/_build/html/.nojekyll
       - name: Set current version
         run: |
-          echo "version=$(git describe --abbrev=0 | cut -d'.' -f1,2)" >> "$GITHUB_ENV"
+          echo "version=$(cat qiskit_experiments/VERSION.txt | cut -d'.' -f1,2)" >> "$GITHUB_ENV"
       - name: Deploy stable
         uses: JamesIves/github-pages-deploy-action@v4
         with:


### PR DESCRIPTION
This PR replaces the buggy `git describe` command, which doesn't register the updated version when doing a release, with the version in `VERSION.txt`. We should test that this works by re-running the stable docs deploy on `main` afterwards. Edit: maybe not since this would build to `stable/0.8` right now after the version bump.